### PR TITLE
Handle files as uri data and build images preview if possible and handle initial data

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -110,7 +110,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
         ''';
 
-  Future<List<XFile>?> defaultCustomFileHandler() async {
+  Future<List<XFile>?> defaultCustomFileHandler(SchemaProperty property) async {
     await Future.delayed(const Duration(seconds: 3));
 
     final file1 = XFile(
@@ -140,7 +140,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 },
                 fileHandler: () => {
                   'files': defaultCustomFileHandler,
-                  'file': () async {
+                  'file': (property) async {
                     return [
                       XFile(
                           'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg')

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -196,7 +196,8 @@ class _MyHomePageState extends State<MyHomePage> {
                     icon: const Icon(Icons.plus_one),
                     label: const Text('Add Item'),
                   ),
-                  addFileButtonBuilder: (onPressed, key) {
+                  addFileButtonBuilder: (onPressed, property) {
+                    final key = property.idKey;
                     if (['file', 'file3'].contains(key)) {
                       return OutlinedButton(
                         onPressed: onPressed,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,6 @@
 import 'dart:developer';
+import 'dart:typed_data';
 
-import 'package:cross_file/cross_file.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_jsonschema_builder/flutter_jsonschema_builder.dart';
 
@@ -110,15 +110,31 @@ class _MyHomePageState extends State<MyHomePage> {
 
         ''';
 
-  Future<List<XFile>?> defaultCustomFileHandler(SchemaProperty property) async {
+  Future<List<SchemaFormFile>?> defaultCustomFileHandler(
+      SchemaProperty property) async {
     await Future.delayed(const Duration(seconds: 3));
 
-    final file1 = XFile(
-        'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg');
-    final file2 = XFile(
-        'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg');
-    final file3 = XFile(
-        'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg');
+    final file1 = SchemaFormFile(
+      name:
+          'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg',
+      value:
+          'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg',
+      bytes: Uint8List.fromList([]),
+    );
+    final file2 = SchemaFormFile(
+      name:
+          'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg',
+      value:
+          'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg',
+      bytes: Uint8List.fromList([]),
+    );
+    final file3 = SchemaFormFile(
+      name:
+          'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg',
+      value:
+          'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg',
+      bytes: Uint8List.fromList([]),
+    );
 
     return [file1, file2, file3];
   }
@@ -142,8 +158,13 @@ class _MyHomePageState extends State<MyHomePage> {
                   'files': defaultCustomFileHandler,
                   'file': (property) async {
                     return [
-                      XFile(
-                          'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg')
+                      SchemaFormFile(
+                        name:
+                            'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg',
+                        value:
+                            'https://cdn.mos.cms.futurecdn.net/LEkEkAKZQjXZkzadbHHsVj-970-80.jpg',
+                        bytes: Uint8List.fromList([]),
+                      )
                     ];
                   },
                   '*': defaultCustomFileHandler

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -94,18 +94,18 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.17.0"
+    version: "0.18.1"
   js:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -118,10 +118,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -134,10 +134,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
@@ -150,10 +150,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -203,10 +203,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -216,5 +216,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=2.0.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -41,14 +41,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
-  cross_file:
-    dependency: "direct main"
-    description:
-      name: cross_file
-      sha256: "0b0036e8cccbfbe0555fd83c1d31a6f30b77a96b598b35a5d36dd41f718695e9"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.3+4"
   cupertino_icons:
     dependency: "direct main"
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -146,6 +146,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   path:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -36,7 +36,6 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  cross_file: ^0.3.3+4
 
 dev_dependencies:
   flutter_test:

--- a/lib/flutter_jsonschema_builder.dart
+++ b/lib/flutter_jsonschema_builder.dart
@@ -3,3 +3,4 @@ library flutter_jsonschema_builder;
 export 'src/builder/widget_builder.dart';
 export 'src/models/property_schema.dart';
 export 'src/models/json_form_schema_style.dart';
+export 'src/models/schema_form_file.dart';

--- a/lib/flutter_jsonschema_builder.dart
+++ b/lib/flutter_jsonschema_builder.dart
@@ -1,4 +1,5 @@
 library flutter_jsonschema_builder;
 
 export 'src/builder/widget_builder.dart';
+export 'src/models/property_schema.dart';
 export 'src/models/json_form_schema_style.dart';

--- a/lib/src/builder/array_schema_builder.dart
+++ b/lib/src/builder/array_schema_builder.dart
@@ -115,20 +115,24 @@ class _ArraySchemaBuilderState extends State<ArraySchemaBuilder> {
 
   void _addFirstItem() {
     if (widget.schemaArray.itemsBaseSchema is Object) {
+      final initialData = WidgetBuilderInherited.of(context).data;
       final newSchema = Schema.fromJson(
         widget.schemaArray.itemsBaseSchema,
         id: '0',
         parent: widget.schemaArray,
+        initialData: initialData,
       );
 
       widget.schemaArray.items = [newSchema];
     } else {
+      final initialData = WidgetBuilderInherited.of(context).data;
       widget.schemaArray.items =
           (widget.schemaArray.itemsBaseSchema as List<Map<String, dynamic>>)
               .map((e) => Schema.fromJson(
                     e,
                     id: '0',
                     parent: widget.schemaArray,
+                    initialData: initialData,
                   ))
               .toList();
     }

--- a/lib/src/builder/logic/widget_builder_logic.dart
+++ b/lib/src/builder/logic/widget_builder_logic.dart
@@ -13,6 +13,7 @@ class WidgetBuilderInherited extends InheritedWidget {
     this.fileHandler,
     this.customPickerHandler,
     this.customValidatorHandler,
+    this.onChanged,
   }) : super(key: key, child: child);
 
   final Schema mainSchema;
@@ -21,6 +22,7 @@ class WidgetBuilderInherited extends InheritedWidget {
   final FileHandler? fileHandler;
   final CustomPickerHandler? customPickerHandler;
   final CustomValidatorHandler? customValidatorHandler;
+  final ValueChanged<dynamic>? onChanged;
   late final JsonFormSchemaUiConfig uiConfig;
 
   void setJsonFormSchemaStyle(
@@ -83,6 +85,7 @@ class WidgetBuilderInherited extends InheritedWidget {
 
     object[_keyNumeric ?? _key] = value;
     stack.removeAt(0);
+    onChanged?.call(data);
   }
 
   /// add a new value into a schema,

--- a/lib/src/builder/logic/widget_builder_logic.dart
+++ b/lib/src/builder/logic/widget_builder_logic.dart
@@ -46,6 +46,7 @@ class WidgetBuilderInherited extends InheritedWidget {
       addFileButtonBuilder: uiConfig?.addFileButtonBuilder,
       imagesBuilder: uiConfig?.imagesBuilder,
       selectionTitle: uiConfig?.selectionTitle,
+      requiredText: uiConfig?.requiredText,
     );
   }
 

--- a/lib/src/builder/logic/widget_builder_logic.dart
+++ b/lib/src/builder/logic/widget_builder_logic.dart
@@ -45,6 +45,7 @@ class WidgetBuilderInherited extends InheritedWidget {
       submitButtonBuilder: uiConfig?.submitButtonBuilder,
       addFileButtonBuilder: uiConfig?.addFileButtonBuilder,
       imagesBuilder: uiConfig?.imagesBuilder,
+      selectionTitle: uiConfig?.selectionTitle,
     );
   }
 

--- a/lib/src/builder/logic/widget_builder_logic.dart
+++ b/lib/src/builder/logic/widget_builder_logic.dart
@@ -44,6 +44,7 @@ class WidgetBuilderInherited extends InheritedWidget {
       removeItemBuilder: uiConfig?.removeItemBuilder,
       submitButtonBuilder: uiConfig?.submitButtonBuilder,
       addFileButtonBuilder: uiConfig?.addFileButtonBuilder,
+      imagesBuilder: uiConfig?.imagesBuilder,
     );
   }
 

--- a/lib/src/builder/logic/widget_builder_logic.dart
+++ b/lib/src/builder/logic/widget_builder_logic.dart
@@ -14,10 +14,12 @@ class WidgetBuilderInherited extends InheritedWidget {
     this.customPickerHandler,
     this.customValidatorHandler,
     this.onChanged,
-  }) : super(key: key, child: child);
+    Map<String, dynamic>? initialData,
+  })  : data = initialData ?? {},
+        super(key: key, child: child);
 
   final Schema mainSchema;
-  final data = {};
+  final Map<String, dynamic> data;
 
   final FileHandler? fileHandler;
   final CustomPickerHandler? customPickerHandler;

--- a/lib/src/builder/property_schema_builder.dart
+++ b/lib/src/builder/property_schema_builder.dart
@@ -309,17 +309,18 @@ class PropertySchemaBuilder extends StatelessWidget {
     }
   }
 
-  Future<List<XFile>?> Function() getCustomFileHanlder(
+  Future<List<XFile>?> Function(SchemaProperty property) getCustomFileHanlder(
       FileHandler customFileHandler, String key) {
     final handlers = customFileHandler();
     assert(handlers.isNotEmpty, 'CustomFileHandler must not be empty');
 
-    if (handlers.containsKey(key))
-      return handlers[key] as Future<List<XFile>?> Function();
+    if (handlers.containsKey(key)) {
+      return handlers[key] as Future<List<XFile>?> Function(SchemaProperty);
+    }
 
     if (handlers.containsKey('*')) {
       assert(handlers['*'] != null, 'Default file handler must not be null');
-      return handlers['*'] as Future<List<XFile>?> Function();
+      return handlers['*'] as Future<List<XFile>?> Function(SchemaProperty);
     }
 
     throw Exception('no file handler found');

--- a/lib/src/builder/property_schema_builder.dart
+++ b/lib/src/builder/property_schema_builder.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:developer';
 
-import 'package:cross_file/cross_file.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_jsonschema_builder/src/builder/logic/object_schema_logic.dart';
@@ -309,18 +308,20 @@ class PropertySchemaBuilder extends StatelessWidget {
     }
   }
 
-  Future<List<XFile>?> Function(SchemaProperty property) getCustomFileHanlder(
-      FileHandler customFileHandler, String key) {
+  Future<List<SchemaFormFile>?> Function(SchemaProperty property)
+      getCustomFileHanlder(FileHandler customFileHandler, String key) {
     final handlers = customFileHandler();
     assert(handlers.isNotEmpty, 'CustomFileHandler must not be empty');
 
     if (handlers.containsKey(key)) {
-      return handlers[key] as Future<List<XFile>?> Function(SchemaProperty);
+      return handlers[key] as Future<List<SchemaFormFile>?> Function(
+          SchemaProperty);
     }
 
     if (handlers.containsKey('*')) {
       assert(handlers['*'] != null, 'Default file handler must not be null');
-      return handlers['*'] as Future<List<XFile>?> Function(SchemaProperty);
+      return handlers['*'] as Future<List<SchemaFormFile>?> Function(
+          SchemaProperty);
     }
 
     throw Exception('no file handler found');
@@ -328,12 +329,12 @@ class PropertySchemaBuilder extends StatelessWidget {
 
   Future<dynamic> Function(Map<dynamic, dynamic>)? _getCustomPickerHanlder(
       BuildContext context, String key) {
-    final customFileHandler =
+    final customPickerHandler =
         WidgetBuilderInherited.of(context).customPickerHandler;
 
-    if (customFileHandler == null) return null;
+    if (customPickerHandler == null) return null;
 
-    final handlers = customFileHandler();
+    final handlers = customPickerHandler();
 
     if (handlers.containsKey(key)) return handlers[key];
 

--- a/lib/src/builder/widget_builder.dart
+++ b/lib/src/builder/widget_builder.dart
@@ -14,7 +14,9 @@ import 'package:flutter_jsonschema_builder/src/models/json_form_schema_style.dar
 
 import '../models/models.dart';
 
-typedef FileHandler = Map<String, Future<List<XFile>?> Function()?> Function();
+typedef FileHandler
+    = Map<String, Future<List<XFile>?> Function(SchemaProperty property)?>
+        Function();
 typedef CustomPickerHandler = Map<String, Future<dynamic> Function(Map data)>
     Function();
 

--- a/lib/src/builder/widget_builder.dart
+++ b/lib/src/builder/widget_builder.dart
@@ -31,7 +31,6 @@ class JsonForm extends StatefulWidget {
     this.customValidatorHandler,
     this.onChanged,
     this.initialData,
-    this.scrollController,
   }) : super(key: key);
 
   final String jsonSchema;
@@ -49,8 +48,6 @@ class JsonForm extends StatefulWidget {
   final ValueChanged<dynamic>? onChanged;
 
   final Map<String, dynamic>? initialData;
-
-  final ScrollController? scrollController;
 
   @override
   _JsonFormState createState() => _JsonFormState();
@@ -84,39 +81,33 @@ class _JsonFormState extends State<JsonForm> {
       child: Builder(builder: (context) {
         final widgetBuilderInherited = WidgetBuilderInherited.of(context);
 
-        return Scrollbar(
-          controller: widget.scrollController,
-          child: SingleChildScrollView(
-            controller: widget.scrollController,
-            child: Form(
-              key: _formKey,
-              child: Container(
-                padding: const EdgeInsets.all(15.0),
-                child: Column(
-                  children: <Widget>[
-                    if (!kReleaseMode)
-                      TextButton(
-                        onPressed: () {
-                          inspect(mainSchema);
-                        },
-                        child: const Text('INSPECT'),
-                      ),
-                    _buildHeaderTitle(context),
-                    FormFromSchemaBuilder(
-                      mainSchema: mainSchema,
-                      schema: mainSchema,
-                    ),
-                    const SizedBox(height: 20),
-                    widgetBuilderInherited.uiConfig.submitButtonBuilder == null
-                        ? ElevatedButton(
-                            onPressed: () => onSubmit(widgetBuilderInherited),
-                            child: const Text('Submit'),
-                          )
-                        : widgetBuilderInherited
-                            .uiConfig.submitButtonBuilder!(() => onSubmit(widgetBuilderInherited)),
-                  ],
+        return Form(
+          key: _formKey,
+          child: Container(
+            padding: const EdgeInsets.all(15.0),
+            child: Column(
+              children: <Widget>[
+                if (!kReleaseMode)
+                  TextButton(
+                    onPressed: () {
+                      inspect(mainSchema);
+                    },
+                    child: const Text('INSPECT'),
+                  ),
+                _buildHeaderTitle(context),
+                FormFromSchemaBuilder(
+                  mainSchema: mainSchema,
+                  schema: mainSchema,
                 ),
-              ),
+                const SizedBox(height: 20),
+                widgetBuilderInherited.uiConfig.submitButtonBuilder == null
+                    ? ElevatedButton(
+                        onPressed: () => onSubmit(widgetBuilderInherited),
+                        child: const Text('Submit'),
+                      )
+                    : widgetBuilderInherited
+                        .uiConfig.submitButtonBuilder!(() => onSubmit(widgetBuilderInherited)),
+              ],
             ),
           ),
         );

--- a/lib/src/builder/widget_builder.dart
+++ b/lib/src/builder/widget_builder.dart
@@ -13,14 +13,11 @@ import 'package:flutter_jsonschema_builder/src/models/json_form_schema_style.dar
 
 import '../models/models.dart';
 
-typedef FileHandler = Map<String,
-        Future<List<SchemaFormFile>?> Function(SchemaProperty property)?>
+typedef FileHandler = Map<String, Future<List<SchemaFormFile>?> Function(SchemaProperty property)?>
     Function();
-typedef CustomPickerHandler = Map<String, Future<dynamic> Function(Map data)>
-    Function();
+typedef CustomPickerHandler = Map<String, Future<dynamic> Function(Map data)> Function();
 
-typedef CustomValidatorHandler = Map<String, String? Function(dynamic)?>
-    Function();
+typedef CustomValidatorHandler = Map<String, String? Function(dynamic)?> Function();
 
 class JsonForm extends StatefulWidget {
   const JsonForm({
@@ -34,6 +31,7 @@ class JsonForm extends StatefulWidget {
     this.customValidatorHandler,
     this.onChanged,
     this.initialData,
+    this.scrollController,
   }) : super(key: key);
 
   final String jsonSchema;
@@ -52,6 +50,8 @@ class JsonForm extends StatefulWidget {
 
   final Map<String, dynamic>? initialData;
 
+  final ScrollController? scrollController;
+
   @override
   _JsonFormState createState() => _JsonFormState();
 }
@@ -67,8 +67,7 @@ class _JsonFormState extends State<JsonForm> {
   void initState() {
     mainSchema = (Schema.fromJson(json.decode(widget.jsonSchema),
         id: kGenesisIdKey, initialData: widget.initialData) as SchemaObject)
-      ..setUiSchema(
-          widget.uiSchema != null ? json.decode(widget.uiSchema!) : null);
+      ..setUiSchema(widget.uiSchema != null ? json.decode(widget.uiSchema!) : null);
 
     super.initState();
   }
@@ -86,6 +85,7 @@ class _JsonFormState extends State<JsonForm> {
         final widgetBuilderInherited = WidgetBuilderInherited.of(context);
 
         return SingleChildScrollView(
+          controller: widget.scrollController,
           child: Form(
             key: _formKey,
             child: Container(
@@ -110,8 +110,8 @@ class _JsonFormState extends State<JsonForm> {
                           onPressed: () => onSubmit(widgetBuilderInherited),
                           child: const Text('Submit'),
                         )
-                      : widgetBuilderInherited.uiConfig.submitButtonBuilder!(
-                          () => onSubmit(widgetBuilderInherited)),
+                      : widgetBuilderInherited
+                          .uiConfig.submitButtonBuilder!(() => onSubmit(widgetBuilderInherited)),
                 ],
               ),
             ),

--- a/lib/src/builder/widget_builder.dart
+++ b/lib/src/builder/widget_builder.dart
@@ -84,35 +84,38 @@ class _JsonFormState extends State<JsonForm> {
       child: Builder(builder: (context) {
         final widgetBuilderInherited = WidgetBuilderInherited.of(context);
 
-        return SingleChildScrollView(
+        return Scrollbar(
           controller: widget.scrollController,
-          child: Form(
-            key: _formKey,
-            child: Container(
-              padding: const EdgeInsets.all(15.0),
-              child: Column(
-                children: <Widget>[
-                  if (!kReleaseMode)
-                    TextButton(
-                      onPressed: () {
-                        inspect(mainSchema);
-                      },
-                      child: const Text('INSPECT'),
+          child: SingleChildScrollView(
+            controller: widget.scrollController,
+            child: Form(
+              key: _formKey,
+              child: Container(
+                padding: const EdgeInsets.all(15.0),
+                child: Column(
+                  children: <Widget>[
+                    if (!kReleaseMode)
+                      TextButton(
+                        onPressed: () {
+                          inspect(mainSchema);
+                        },
+                        child: const Text('INSPECT'),
+                      ),
+                    _buildHeaderTitle(context),
+                    FormFromSchemaBuilder(
+                      mainSchema: mainSchema,
+                      schema: mainSchema,
                     ),
-                  _buildHeaderTitle(context),
-                  FormFromSchemaBuilder(
-                    mainSchema: mainSchema,
-                    schema: mainSchema,
-                  ),
-                  const SizedBox(height: 20),
-                  widgetBuilderInherited.uiConfig.submitButtonBuilder == null
-                      ? ElevatedButton(
-                          onPressed: () => onSubmit(widgetBuilderInherited),
-                          child: const Text('Submit'),
-                        )
-                      : widgetBuilderInherited
-                          .uiConfig.submitButtonBuilder!(() => onSubmit(widgetBuilderInherited)),
-                ],
+                    const SizedBox(height: 20),
+                    widgetBuilderInherited.uiConfig.submitButtonBuilder == null
+                        ? ElevatedButton(
+                            onPressed: () => onSubmit(widgetBuilderInherited),
+                            child: const Text('Submit'),
+                          )
+                        : widgetBuilderInherited
+                            .uiConfig.submitButtonBuilder!(() => onSubmit(widgetBuilderInherited)),
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/src/builder/widget_builder.dart
+++ b/lib/src/builder/widget_builder.dart
@@ -3,7 +3,6 @@
 import 'dart:convert';
 import 'dart:developer';
 
-import 'package:cross_file/cross_file.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_jsonschema_builder/src/builder/array_schema_builder.dart';
@@ -14,9 +13,9 @@ import 'package:flutter_jsonschema_builder/src/models/json_form_schema_style.dar
 
 import '../models/models.dart';
 
-typedef FileHandler
-    = Map<String, Future<List<XFile>?> Function(SchemaProperty property)?>
-        Function();
+typedef FileHandler = Map<String,
+        Future<List<SchemaFormFile>?> Function(SchemaProperty property)?>
+    Function();
 typedef CustomPickerHandler = Map<String, Future<dynamic> Function(Map data)>
     Function();
 
@@ -67,7 +66,7 @@ class _JsonFormState extends State<JsonForm> {
   @override
   void initState() {
     mainSchema = (Schema.fromJson(json.decode(widget.jsonSchema),
-        id: kGenesisIdKey) as SchemaObject)
+        id: kGenesisIdKey, initialData: widget.initialData) as SchemaObject)
       ..setUiSchema(
           widget.uiSchema != null ? json.decode(widget.uiSchema!) : null);
 

--- a/lib/src/builder/widget_builder.dart
+++ b/lib/src/builder/widget_builder.dart
@@ -34,6 +34,7 @@ class JsonForm extends StatefulWidget {
     this.customPickerHandler,
     this.customValidatorHandler,
     this.onChanged,
+    this.initialData,
   }) : super(key: key);
 
   final String jsonSchema;
@@ -49,6 +50,8 @@ class JsonForm extends StatefulWidget {
   final CustomValidatorHandler? customValidatorHandler;
 
   final ValueChanged<dynamic>? onChanged;
+
+  final Map<String, dynamic>? initialData;
 
   @override
   _JsonFormState createState() => _JsonFormState();
@@ -79,6 +82,7 @@ class _JsonFormState extends State<JsonForm> {
       customPickerHandler: widget.customPickerHandler,
       customValidatorHandler: widget.customValidatorHandler,
       onChanged: widget.onChanged,
+      initialData: widget.initialData,
       child: Builder(builder: (context) {
         final widgetBuilderInherited = WidgetBuilderInherited.of(context);
 

--- a/lib/src/builder/widget_builder.dart
+++ b/lib/src/builder/widget_builder.dart
@@ -33,6 +33,7 @@ class JsonForm extends StatefulWidget {
     this.jsonFormSchemaUiConfig,
     this.customPickerHandler,
     this.customValidatorHandler,
+    this.onChanged,
   }) : super(key: key);
 
   final String jsonSchema;
@@ -46,6 +47,9 @@ class JsonForm extends StatefulWidget {
   final CustomPickerHandler? customPickerHandler;
 
   final CustomValidatorHandler? customValidatorHandler;
+
+  final ValueChanged<dynamic>? onChanged;
+
   @override
   _JsonFormState createState() => _JsonFormState();
 }
@@ -74,6 +78,7 @@ class _JsonFormState extends State<JsonForm> {
       fileHandler: widget.fileHandler,
       customPickerHandler: widget.customPickerHandler,
       customValidatorHandler: widget.customValidatorHandler,
+      onChanged: widget.onChanged,
       child: Builder(builder: (context) {
         final widgetBuilderInherited = WidgetBuilderInherited.of(context);
 

--- a/lib/src/fields/date_form_field.dart
+++ b/lib/src/fields/date_form_field.dart
@@ -61,8 +61,7 @@ class _DateJFormFieldState extends State<DateJFormField> {
             if (widget.property.required && (value == null || value.isEmpty)) {
               return uiConfig.requiredText ?? 'Required';
             }
-            if (widget.customValidator != null)
-              return widget.customValidator!(value);
+            if (widget.customValidator != null) return widget.customValidator!(value);
             return null;
           },
           // inputFormatters: [DateTextInputJsonFormatter()],
@@ -72,7 +71,9 @@ class _DateJFormFieldState extends State<DateJFormField> {
               : WidgetBuilderInherited.of(context).uiConfig.label,
 
           onSaved: (value) {
-            if (value != null) widget.onSaved(formatter.parse(value));
+            if (value != null && DateTime.tryParse(value) != null) {
+              widget.onSaved(formatter.parse(value));
+            }
           },
           onChanged: (value) {
             try {
@@ -84,10 +85,9 @@ class _DateJFormFieldState extends State<DateJFormField> {
           },
           decoration: InputDecoration(
             hintText: dateFormatString.toUpperCase(),
-            helperText:
-                widget.property.help != null && widget.property.help!.isNotEmpty
-                    ? widget.property.help
-                    : null,
+            helperText: widget.property.help != null && widget.property.help!.isNotEmpty
+                ? widget.property.help
+                : null,
             suffixIcon: IconButton(
               icon: const Icon(Icons.date_range_outlined),
               onPressed: widget.property.readOnly ? null : _openCalendar,

--- a/lib/src/fields/date_form_field.dart
+++ b/lib/src/fields/date_form_field.dart
@@ -45,12 +45,13 @@ class _DateJFormFieldState extends State<DateJFormField> {
 
   @override
   Widget build(BuildContext context) {
+    final uiConfig = WidgetBuilderInherited.of(context).uiConfig;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
           '${widget.property.title} ${widget.property.required ? "*" : ""}',
-          style: WidgetBuilderInherited.of(context).uiConfig.fieldTitle,
+          style: uiConfig.fieldTitle,
         ),
         TextFormField(
           key: Key(widget.property.idKey),
@@ -58,7 +59,7 @@ class _DateJFormFieldState extends State<DateJFormField> {
           keyboardType: TextInputType.phone,
           validator: (value) {
             if (widget.property.required && (value == null || value.isEmpty)) {
-              return 'Required';
+              return uiConfig.requiredText ?? 'Required';
             }
             if (widget.customValidator != null)
               return widget.customValidator!(value);

--- a/lib/src/fields/dropdown_form_field.dart
+++ b/lib/src/fields/dropdown_form_field.dart
@@ -58,11 +58,14 @@ class _DropDownJFormFieldState extends State<DropDownJFormField> {
       return true;
     }(), '[enumNames] and [enum]  must be the same size ');
 
+    final uiConfig = WidgetBuilderInherited.of(context).uiConfig;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('${widget.property.title} ${widget.property.required ? "*" : ""}',
-            style: WidgetBuilderInherited.of(context).uiConfig.fieldTitle),
+        Text(
+          '${widget.property.title} ${widget.property.required ? "*" : ""}',
+          style: uiConfig.fieldTitle,
+        ),
         GestureDetector(
           onTap: _onTap,
           child: AbsorbPointer(
@@ -70,7 +73,7 @@ class _DropDownJFormFieldState extends State<DropDownJFormField> {
             child: DropdownButtonFormField<dynamic>(
               key: Key(widget.property.idKey),
               autovalidateMode: AutovalidateMode.onUserInteraction,
-              hint: const Text('Seleccione'),
+              hint: Text(uiConfig.selectionTitle ?? 'Select'),
               isExpanded: false,
               validator: (value) {
                 if (widget.property.required && value == null) {

--- a/lib/src/fields/dropdown_form_field.dart
+++ b/lib/src/fields/dropdown_form_field.dart
@@ -77,7 +77,7 @@ class _DropDownJFormFieldState extends State<DropDownJFormField> {
               isExpanded: false,
               validator: (value) {
                 if (widget.property.required && value == null) {
-                  return uiConfig.requiredText ?? 'required';
+                  return uiConfig.requiredText ?? 'Required';
                 }
                 if (widget.customValidator != null)
                   return widget.customValidator!(value);

--- a/lib/src/fields/dropdown_form_field.dart
+++ b/lib/src/fields/dropdown_form_field.dart
@@ -77,7 +77,7 @@ class _DropDownJFormFieldState extends State<DropDownJFormField> {
               isExpanded: false,
               validator: (value) {
                 if (widget.property.required && value == null) {
-                  return 'required';
+                  return uiConfig.requiredText ?? 'required';
                 }
                 if (widget.customValidator != null)
                   return widget.customValidator!(value);

--- a/lib/src/fields/dropdown_oneof_form_field.dart
+++ b/lib/src/fields/dropdown_oneof_form_field.dart
@@ -82,11 +82,14 @@ class _SelectedFormFieldState extends State<DropdownOneOfJFormField> {
   Widget build(BuildContext context) {
     assert(widget.property.oneOf != null, 'oneOf is required');
 
+    final uiConfig = WidgetBuilderInherited.of(context).uiConfig;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('${widget.property.title} ${widget.property.required ? "*" : ""}',
-            style: WidgetBuilderInherited.of(context).uiConfig.fieldTitle),
+        Text(
+          '${widget.property.title} ${widget.property.required ? "*" : ""}',
+          style: uiConfig.fieldTitle,
+        ),
         GestureDetector(
           onTap: _onTap,
           child: AbsorbPointer(
@@ -95,7 +98,7 @@ class _SelectedFormFieldState extends State<DropdownOneOfJFormField> {
               key: Key(widget.property.idKey),
               value: valueSelected,
               autovalidateMode: AutovalidateMode.onUserInteraction,
-              hint: const Text('Seleccione'),
+              hint: Text(uiConfig.selectionTitle ?? 'Select'),
               isExpanded: false,
               validator: (value) {
                 if (widget.property.required && value == null) {

--- a/lib/src/fields/dropdown_oneof_form_field.dart
+++ b/lib/src/fields/dropdown_oneof_form_field.dart
@@ -102,7 +102,7 @@ class _SelectedFormFieldState extends State<DropdownOneOfJFormField> {
               isExpanded: false,
               validator: (value) {
                 if (widget.property.required && value == null) {
-                  return 'required';
+                  return uiConfig.requiredText ?? 'Required';
                 }
                 if (widget.customValidator != null)
                   return widget.customValidator!(value);

--- a/lib/src/fields/file_form_field.dart
+++ b/lib/src/fields/file_form_field.dart
@@ -168,8 +168,8 @@ class _FileJFormFieldState extends State<FileJFormField> {
         widgetBuilderInherited.uiConfig.addFileButtonBuilder;
 
     if (addFileButtonBuilder != null &&
-        addFileButtonBuilder(_onTap(field), widget.property.idKey) != null) {
-      return addFileButtonBuilder(_onTap(field), widget.property.idKey)!;
+        addFileButtonBuilder(_onTap(field), widget.property) != null) {
+      return addFileButtonBuilder(_onTap(field), widget.property)!;
     }
 
     return ElevatedButton(

--- a/lib/src/fields/file_form_field.dart
+++ b/lib/src/fields/file_form_field.dart
@@ -46,7 +46,7 @@ class _FileJFormFieldState extends State<FileJFormField> {
       key: Key(widget.property.idKey),
       validator: (value) {
         if ((value == null || value.isEmpty) && widget.property.required) {
-          return 'Required';
+          return widgetBuilderInherited.uiConfig.requiredText ?? 'Required';
         }
 
         if (widget.customValidator != null)

--- a/lib/src/fields/file_form_field.dart
+++ b/lib/src/fields/file_form_field.dart
@@ -25,7 +25,7 @@ class FileJFormField extends PropertyFieldWidget<dynamic> {
           customValidator: customValidator,
         );
 
-  final Future<List<XFile>?> Function() fileHandler;
+  final Future<List<XFile>?> Function(SchemaProperty property) fileHandler;
 
   @override
   _FileJFormFieldState createState() => _FileJFormFieldState();
@@ -63,10 +63,10 @@ class _FileJFormFieldState extends State<FileJFormField> {
       },
       builder: (field) {
         final images = _extractImages(field.value);
-        final shouldBuildImages =
+        final shouldBuildImages = widget.property.filePreview &&
             widgetBuilderInherited.uiConfig.imagesBuilder != null &&
-                images != null &&
-                images.isNotEmpty;
+            images != null &&
+            images.isNotEmpty;
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -139,7 +139,7 @@ class _FileJFormFieldState extends State<FileJFormField> {
     if (widget.property.readOnly) return null;
 
     return () async {
-      final result = await widget.fileHandler();
+      final result = await widget.fileHandler(widget.property);
 
       if (result != null) {
         final urlData = await Future.wait(

--- a/lib/src/fields/number_form_field.dart
+++ b/lib/src/fields/number_form_field.dart
@@ -42,11 +42,14 @@ class _NumberJFormFieldState extends State<NumberJFormField> {
 
   @override
   Widget build(BuildContext context) {
+    final uiConfig = WidgetBuilderInherited.of(context).uiConfig;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('${widget.property.title} ${widget.property.required ? "*" : ""}',
-            style: WidgetBuilderInherited.of(context).uiConfig.fieldTitle),
+        Text(
+          '${widget.property.title} ${widget.property.required ? "*" : ""}',
+          style: uiConfig.fieldTitle,
+        ),
         TextFormField(
           key: Key(widget.property.idKey),
           keyboardType: TextInputType.number,
@@ -69,7 +72,7 @@ class _NumberJFormFieldState extends State<NumberJFormField> {
               : WidgetBuilderInherited.of(context).uiConfig.label,
           validator: (String? value) {
             if (widget.property.required && value != null && value.isEmpty) {
-              return 'Required';
+              return uiConfig.requiredText ?? 'Required';
             }
             if (widget.property.minLength != null &&
                 value != null &&

--- a/lib/src/fields/text_form_field.dart
+++ b/lib/src/fields/text_form_field.dart
@@ -45,11 +45,12 @@ class _TextJFormFieldState extends State<TextJFormField> {
 
   @override
   Widget build(BuildContext context) {
+    final uiConfig = WidgetBuilderInherited.of(context).uiConfig;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text('${widget.property.title} ${widget.property.required ? "*" : ""}',
-            style: WidgetBuilderInherited.of(context).uiConfig.fieldTitle),
+            style: uiConfig.fieldTitle),
         AbsorbPointer(
           absorbing: widget.property.disabled ?? false,
           child: TextFormField(
@@ -75,7 +76,11 @@ class _TextJFormFieldState extends State<TextJFormField> {
               if (widget.property.required && value != null) {
                 final validated = inputValidationJsonSchema(
                     newValue: value, property: widget.property);
-                if (validated != null) return validated;
+                if (validated == 'Required') {
+                  return uiConfig.requiredText ?? validated;
+                } else {
+                  return validated;
+                }
               }
 
               if (widget.customValidator != null)

--- a/lib/src/models/json_form_schema_style.dart
+++ b/lib/src/models/json_form_schema_style.dart
@@ -17,6 +17,7 @@ class JsonFormSchemaUiConfig {
     this.addFileButtonBuilder,
     this.imagesBuilder,
     this.selectionTitle,
+    this.requiredText,
   });
 
   TextStyle? fieldTitle;

--- a/lib/src/models/json_form_schema_style.dart
+++ b/lib/src/models/json_form_schema_style.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 
 class JsonFormSchemaUiConfig {
@@ -23,8 +25,8 @@ class JsonFormSchemaUiConfig {
   TextStyle? description;
   TextStyle? label;
 
-  Widget Function(VoidCallback onPressed,String key)? addItemBuilder;
-  Widget Function(VoidCallback onPressed,String key)? removeItemBuilder;
+  Widget Function(VoidCallback onPressed, String key)? addItemBuilder;
+  Widget Function(VoidCallback onPressed, String key)? removeItemBuilder;
 
   /// render a custom submit button
   /// @param [VoidCallback] submit function
@@ -34,4 +36,9 @@ class JsonFormSchemaUiConfig {
   /// if it returns null or it is null, it will build default buttom
   Widget? Function(VoidCallback? onPressed, String key)? addFileButtonBuilder;
 
+  /// render a custom image preview, it takes a list of Uint8List (image bytes) as a parameter
+  /// this widget is typically shown above the [addFileButtonBuilder] or default button in file field
+  ///
+  /// if it returns null or it is null, images won't be rendered
+  Widget Function(List<Uint8List> images)? imagesBuilder;
 }

--- a/lib/src/models/json_form_schema_style.dart
+++ b/lib/src/models/json_form_schema_style.dart
@@ -31,6 +31,10 @@ class JsonFormSchemaUiConfig {
   /// if it is null, it will default to "Select"
   String? selectionTitle;
 
+  /// text of the required fields
+  /// if it is null, it will default to "Required"
+  String? requiredText;
+
   Widget Function(VoidCallback onPressed, String key)? addItemBuilder;
   Widget Function(VoidCallback onPressed, String key)? removeItemBuilder;
 

--- a/lib/src/models/json_form_schema_style.dart
+++ b/lib/src/models/json_form_schema_style.dart
@@ -15,6 +15,7 @@ class JsonFormSchemaUiConfig {
     this.removeItemBuilder,
     this.submitButtonBuilder,
     this.addFileButtonBuilder,
+    this.imagesBuilder,
   });
 
   TextStyle? fieldTitle;

--- a/lib/src/models/json_form_schema_style.dart
+++ b/lib/src/models/json_form_schema_style.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_jsonschema_builder/flutter_jsonschema_builder.dart';
 
 class JsonFormSchemaUiConfig {
   JsonFormSchemaUiConfig({
@@ -45,7 +46,8 @@ class JsonFormSchemaUiConfig {
 
   /// render a custom button
   /// if it returns null or it is null, it will build default buttom
-  Widget? Function(VoidCallback? onPressed, String key)? addFileButtonBuilder;
+  Widget? Function(VoidCallback? onPressed, SchemaProperty property)?
+      addFileButtonBuilder;
 
   /// render a custom image preview, it takes a list of Uint8List (image bytes) as a parameter
   /// this widget is typically shown above the [addFileButtonBuilder] or default button in file field

--- a/lib/src/models/json_form_schema_style.dart
+++ b/lib/src/models/json_form_schema_style.dart
@@ -16,6 +16,7 @@ class JsonFormSchemaUiConfig {
     this.submitButtonBuilder,
     this.addFileButtonBuilder,
     this.imagesBuilder,
+    this.selectionTitle,
   });
 
   TextStyle? fieldTitle;
@@ -25,6 +26,10 @@ class JsonFormSchemaUiConfig {
   TextStyle? subtitle;
   TextStyle? description;
   TextStyle? label;
+
+  /// title of the selection widget
+  /// if it is null, it will default to "Select"
+  String? selectionTitle;
 
   Widget Function(VoidCallback onPressed, String key)? addItemBuilder;
   Widget Function(VoidCallback onPressed, String key)? removeItemBuilder;

--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -2,6 +2,7 @@ export 'schema.dart';
 export 'array_schema.dart';
 export 'object_schema.dart';
 export 'property_schema.dart';
+export 'schema_form_file.dart';
 
 const String kNoTitle = 'no-title';
 const String kGenesisIdKey = 'genesis-key';

--- a/lib/src/models/object_schema.dart
+++ b/lib/src/models/object_schema.dart
@@ -18,6 +18,7 @@ class SchemaObject extends Schema {
     String id,
     Map<String, dynamic> json, {
     Schema? parent,
+    Map<String, dynamic>? initialData,
   }) {
     final schema = SchemaObject(
       id: id,
@@ -33,10 +34,10 @@ class SchemaObject extends Schema {
     schema.dependentsAddedBy.addAll(parent?.dependentsAddedBy ?? []);
 
     if (json['properties'] != null) {
-      schema.setProperties(json['properties'], schema);
+      schema.setProperties(json['properties'], schema, initialData);
     }
     if (json['oneOf'] != null) {
-      schema.setOneOf(json['oneOf'], schema);
+      schema.setOneOf(json['oneOf'], schema, initialData);
     }
 
     return schema;
@@ -137,6 +138,7 @@ class SchemaObject extends Schema {
   void setProperties(
     dynamic properties,
     SchemaObject schema,
+    Map<String, dynamic>? initialData,
   ) {
     if (properties == null) return;
     var props = <Schema>[];
@@ -149,6 +151,7 @@ class SchemaObject extends Schema {
         _property,
         id: key,
         parent: schema,
+        initialData: initialData,
       );
 
       if (property is SchemaProperty) {
@@ -165,13 +168,21 @@ class SchemaObject extends Schema {
     this.properties = props;
   }
 
-  void setOneOf(List<dynamic>? oneOf, SchemaObject schema) {
+  void setOneOf(
+    List<dynamic>? oneOf,
+    SchemaObject schema,
+    Map<String, dynamic>? initialData,
+  ) {
     if (oneOf == null) return;
     oneOf.map((e) => Map<String, dynamic>.from(e));
     var oneOfs = <Schema>[];
     for (var element in oneOf) {
       print(element);
-      oneOfs.add(Schema.fromJson(element, parent: schema));
+      oneOfs.add(Schema.fromJson(
+        element,
+        parent: schema,
+        initialData: initialData,
+      ));
     }
 
     this.oneOf = oneOfs;

--- a/lib/src/models/property_schema.dart
+++ b/lib/src/models/property_schema.dart
@@ -58,13 +58,14 @@ class SchemaProperty extends Schema {
     String id,
     Map<String, dynamic> json, {
     Schema? parent,
+    Map<String, dynamic>? initialData,
   }) {
     final property = SchemaProperty(
       id: id,
       title: json['title'],
       type: schemaTypeFromString(json['type']),
       format: propertyFormatFromString(json['format']),
-      defaultValue: safeDefaultValue(json),
+      defaultValue: initialData?[id] ?? safeDefaultValue(json),
       description: json['description'],
       enumm: json['enum'],
       enumNames: json['enumNames'],

--- a/lib/src/models/property_schema.dart
+++ b/lib/src/models/property_schema.dart
@@ -145,6 +145,8 @@ class SchemaProperty extends Schema {
   dynamic dependents;
   bool readOnly;
   bool isMultipleFile = false;
+  bool filePreview = false;
+  List<String>? acceptedFiles;
 
   /// indica si sus dependentes han sido activados por XDependencies
   bool isDependentsActive = false;
@@ -199,6 +201,15 @@ class SchemaProperty extends Schema {
           break;
         case "ui:widget":
           widget = data as String;
+          break;
+        case "ui:options":
+          filePreview = data["filePreview"] ?? false;
+          acceptedFiles = data["accept"] != null
+              ? (data["accept"] as String)
+                  .split(',')
+                  .map((e) => e.trim())
+                  .toList()
+              : null;
           break;
         default:
           break;

--- a/lib/src/models/property_schema.dart
+++ b/lib/src/models/property_schema.dart
@@ -146,6 +146,7 @@ class SchemaProperty extends Schema {
   bool readOnly;
   bool isMultipleFile = false;
   bool filePreview = false;
+  String? fileType;
   List<String>? acceptedFiles;
 
   /// indica si sus dependentes han sido activados por XDependencies
@@ -204,6 +205,7 @@ class SchemaProperty extends Schema {
           break;
         case "ui:options":
           filePreview = data["filePreview"] ?? false;
+          fileType = data["fileType"];
           acceptedFiles = data["accept"] != null
               ? (data["accept"] as String)
                   .split(',')

--- a/lib/src/models/schema.dart
+++ b/lib/src/models/schema.dart
@@ -22,6 +22,7 @@ class Schema {
     Map<String, dynamic> json, {
     String id = kNoIdKey,
     Schema? parent,
+    Map<String, dynamic>? initialData,
   }) {
     Schema schema;
 
@@ -33,10 +34,16 @@ class Schema {
     }
 
     json['type'] ??= 'object';
+    print('in Schema initialData: $initialData');
 
     switch (schemaTypeFromString(json['type'])) {
       case SchemaType.object:
-        schema = SchemaObject.fromJson(id, json, parent: parent);
+        schema = SchemaObject.fromJson(
+          id,
+          json,
+          parent: parent,
+          initialData: initialData,
+        );
         break;
 
       case SchemaType.array:
@@ -47,9 +54,13 @@ class Schema {
           schema = schema.toSchemaPropertyMultipleFiles();
 
         break;
-
       default:
-        schema = SchemaProperty.fromJson(id, json, parent: parent);
+        schema = SchemaProperty.fromJson(
+          id,
+          json,
+          parent: parent,
+          initialData: initialData,
+        );
         break;
     }
 

--- a/lib/src/models/schema_form_file.dart
+++ b/lib/src/models/schema_form_file.dart
@@ -1,0 +1,33 @@
+import 'dart:typed_data';
+
+/// Representation of a file in the schema form
+///
+/// It holds the title that will be displayed in the form
+class SchemaFormFile {
+  SchemaFormFile({
+    required this.name,
+    required this.value,
+    required this.bytes,
+  });
+
+  /// The name of the file, used for comsetic reasons
+  String name;
+
+  /// The value of the file, used for the form
+  String value;
+
+  /// The bytes of the file, used for cosmetic reasons when displaying previews
+  Uint8List bytes;
+
+  SchemaFormFile copyWith({
+    String? name,
+    String? value,
+    Uint8List? bytes,
+  }) {
+    return SchemaFormFile(
+      name: name ?? this.name,
+      value: value ?? this.value,
+      bytes: bytes ?? this.bytes,
+    );
+  }
+}

--- a/lib/src/utils/input_validation_json_schema.dart
+++ b/lib/src/utils/input_validation_json_schema.dart
@@ -11,10 +11,11 @@ String? inputValidationJsonSchema(
       property.minLength != null) {
     return 'should NOT be shorter than ${property.minLength} characters';
   }
-  
+
   if ((property.format == PropertyFormat.uri)) {
     if (!(isURL(newValue))) {
       return 'you should enter a uri';
     }
   }
+  return null;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,14 +41,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
-  cross_file:
-    dependency: "direct main"
-    description:
-      name: cross_file
-      sha256: "0b0036e8cccbfbe0555fd83c1d31a6f30b77a96b598b35a5d36dd41f718695e9"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.3+4"
   extended_masked_text:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -131,6 +131,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
+  mime:
+    dependency: "direct main"
+    description:
+      name: mime
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   path:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   extended_masked_text:
     dependency: "direct main"
     description:
@@ -79,18 +79,18 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.17.0"
+    version: "0.18.1"
   js:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -103,10 +103,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -119,10 +119,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   mime:
     dependency: "direct main"
     description:
@@ -135,10 +135,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -188,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -201,5 +201,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   intl: ^0.17.0
   extended_masked_text: ^2.3.1
   cross_file: ^0.3.3+4
+  mime: ^1.0.4
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  intl: ^0.17.0
+  intl: ^0.18.0
   extended_masked_text: ^2.3.1
   mime: ^1.0.4
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
 
   intl: ^0.17.0
   extended_masked_text: ^2.3.1
-  cross_file: ^0.3.3+4
   mime: ^1.0.4
 
 dev_dependencies:


### PR DESCRIPTION
The title mentions the biggest three changes, but sadly the PR holds more changes than that.

Going forward we will merge our changes into the `next` branch.

To mention the changes briefly:
* Handle files as URI data and build images preview if possible.
* Pass SchemaProperty to file handler and add preview and accept arguments.
* Add file type UI option.
* Add imagesBuilder to the JsonFormSchemaUiConfig constructor.
* Pass images builder to widget builder logic constructor.
* Add selection text to UI config.
* Allow setting of "Required" validation text and add it to appropriate places.
* Add onChanged optional listener on the form.
* Pass onChanged callback to widget builder from JsonForm.
* Pass property to addFileButton builder instead of key ID.
* Allow passing of initial data.
* Pass initial value and allow users to set file values as they seem necessary.
* Make sure that date time is valid onSaved.
* Upgrade intl dependency.