### PR TITLE
Add `initialFileValueHandler` callback and use key 

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,46 @@ customFileHandler: () => {
 }
 ```
 
+### Initial File Value Handler
+
+As file can be represented as any string, even a URL, so we need a way to convert back that string into an actual file value, we can provide `initialFileValueHandler` for this case
+
+```dart
+initialFileValueHandler: () => {
+  'profile_photo': (dynamic defaultValue) async {
+    if(defaultValue is List) 
+    // fetch list of images logic here
+    return;
+    if(defaultValue is String){
+      final file = await fetchOurFileFromUrl(defaultValue);
+      return [SchemaFormFile(name: file.name, bytes: await file.readAsBytes(), value: defaultValue )]
+    }
+    
+  },
+  '*': null
+}
+
+Future<List<SchemaFormFile>?> _defaultInitialFileValueHandler(
+    dynamic defaultValue) async {
+  Future<SchemaFormFile?> schemaFileFromUrl(String url) async {
+    // file fetching logic here
+  }
+
+  if (defaultValue is List) {
+    final result =
+        await Future.wait(defaultValue.cast<String>().map(schemaFileFromUrl));
+    return result.whereType<SchemaFormFile>().toList();
+  }
+
+  if (defaultValue is String) {
+    final file = await schemaFileFromUrl(defaultValue);
+    if (file != null) return [file];
+  }
+
+  return null;
+}
+```
+
 ### Using Custom Validator
 
 ```dart

--- a/lib/src/builder/logic/widget_builder_logic.dart
+++ b/lib/src/builder/logic/widget_builder_logic.dart
@@ -11,6 +11,7 @@ class WidgetBuilderInherited extends InheritedWidget {
     required this.mainSchema,
     required Widget child,
     this.fileHandler,
+    this.initialFileValueHandler,
     this.customPickerHandler,
     this.customValidatorHandler,
     this.onChanged,
@@ -22,6 +23,7 @@ class WidgetBuilderInherited extends InheritedWidget {
   final Map<String, dynamic> data;
 
   final FileHandler? fileHandler;
+  final InitialFileValueHandler? initialFileValueHandler;
   final CustomPickerHandler? customPickerHandler;
   final CustomValidatorHandler? customValidatorHandler;
   final ValueChanged<dynamic>? onChanged;

--- a/lib/src/builder/property_schema_builder.dart
+++ b/lib/src/builder/property_schema_builder.dart
@@ -137,8 +137,11 @@ class PropertySchemaBuilder extends StatelessWidget {
                 'File handler can not be null when using file inputs');
             _field = FileJFormField(
               property: schemaPropertySorted,
-              fileHandler: getCustomFileHanlder(
+              fileHandler: getCustomFileHandler(
                   WidgetBuilderInherited.of(context).fileHandler!,
+                  schemaProperty.id),
+              initialFileValueHandler: getCustomInitialFileValueHandler(
+                  WidgetBuilderInherited.of(context).initialFileValueHandler,
                   schemaProperty.id),
               onSaved: (val) {
                 log('onSaved: FileJFormField  ${schemaProperty.idKey}  : $val');
@@ -309,7 +312,7 @@ class PropertySchemaBuilder extends StatelessWidget {
   }
 
   Future<List<SchemaFormFile>?> Function(SchemaProperty property)
-      getCustomFileHanlder(FileHandler customFileHandler, String key) {
+      getCustomFileHandler(FileHandler customFileHandler, String key) {
     final handlers = customFileHandler();
     assert(handlers.isNotEmpty, 'CustomFileHandler must not be empty');
 
@@ -325,6 +328,30 @@ class PropertySchemaBuilder extends StatelessWidget {
     }
 
     throw Exception('no file handler found');
+  }
+
+  Future<List<SchemaFormFile>?> Function(dynamic defaultValue)?
+      getCustomInitialFileValueHandler(
+    InitialFileValueHandler? initialFileValueHandler,
+    String key,
+  ) {
+    if (initialFileValueHandler == null) return null;
+    final handlers = initialFileValueHandler();
+    assert(handlers.isNotEmpty, 'InitialFileValueHandlers must not be empty');
+
+    if (handlers.containsKey(key)) {
+      return handlers[key] as Future<List<SchemaFormFile>?> Function(dynamic);
+    }
+
+    if (handlers.containsKey('*')) {
+      assert(
+        handlers['*'] != null,
+        'Default initial file value handler must not be null',
+      );
+      return handlers['*'] as Future<List<SchemaFormFile>?> Function(dynamic);
+    }
+
+    throw Exception('no initial file value handler found');
   }
 
   Future<dynamic> Function(Map<dynamic, dynamic>)? _getCustomPickerHanlder(

--- a/lib/src/builder/widget_builder.dart
+++ b/lib/src/builder/widget_builder.dart
@@ -13,11 +13,17 @@ import 'package:flutter_jsonschema_builder/src/models/json_form_schema_style.dar
 
 import '../models/models.dart';
 
-typedef FileHandler = Map<String, Future<List<SchemaFormFile>?> Function(SchemaProperty property)?>
+typedef FileHandler = Map<String,
+        Future<List<SchemaFormFile>?> Function(SchemaProperty property)?>
     Function();
-typedef CustomPickerHandler = Map<String, Future<dynamic> Function(Map data)> Function();
+typedef InitialFileValueHandler
+    = Map<String, Future<List<SchemaFormFile>?> Function(dynamic defaultValue)?>
+        Function();
+typedef CustomPickerHandler = Map<String, Future<dynamic> Function(Map data)>
+    Function();
 
-typedef CustomValidatorHandler = Map<String, String? Function(dynamic)?> Function();
+typedef CustomValidatorHandler = Map<String, String? Function(dynamic)?>
+    Function();
 
 class JsonForm extends StatefulWidget {
   const JsonForm({
@@ -26,6 +32,7 @@ class JsonForm extends StatefulWidget {
     this.uiSchema,
     required this.onFormDataSaved,
     this.fileHandler,
+    this.initialFileValueHandler,
     this.jsonFormSchemaUiConfig,
     this.customPickerHandler,
     this.customValidatorHandler,
@@ -38,6 +45,10 @@ class JsonForm extends StatefulWidget {
 
   final String? uiSchema;
   final FileHandler? fileHandler;
+
+  /// This handler is for getting the correct initial value for each file, as file is just represented as string sometimes,
+  /// so we would need this handler to turn value into actual representable file field value
+  final InitialFileValueHandler? initialFileValueHandler;
 
   final JsonFormSchemaUiConfig? jsonFormSchemaUiConfig;
 
@@ -64,7 +75,8 @@ class _JsonFormState extends State<JsonForm> {
   void initState() {
     mainSchema = (Schema.fromJson(json.decode(widget.jsonSchema),
         id: kGenesisIdKey, initialData: widget.initialData) as SchemaObject)
-      ..setUiSchema(widget.uiSchema != null ? json.decode(widget.uiSchema!) : null);
+      ..setUiSchema(
+          widget.uiSchema != null ? json.decode(widget.uiSchema!) : null);
 
     super.initState();
   }
@@ -74,6 +86,7 @@ class _JsonFormState extends State<JsonForm> {
     return WidgetBuilderInherited(
       mainSchema: mainSchema,
       fileHandler: widget.fileHandler,
+      initialFileValueHandler: widget.initialFileValueHandler,
       customPickerHandler: widget.customPickerHandler,
       customValidatorHandler: widget.customValidatorHandler,
       onChanged: widget.onChanged,
@@ -105,8 +118,8 @@ class _JsonFormState extends State<JsonForm> {
                         onPressed: () => onSubmit(widgetBuilderInherited),
                         child: const Text('Submit'),
                       )
-                    : widgetBuilderInherited
-                        .uiConfig.submitButtonBuilder!(() => onSubmit(widgetBuilderInherited)),
+                    : widgetBuilderInherited.uiConfig.submitButtonBuilder!(
+                        () => onSubmit(widgetBuilderInherited)),
               ],
             ),
           ),


### PR DESCRIPTION
### Changes
* Add `initialFileValueHandler` for optionally handling the initial value of the file form field state.
* Replace passing around the file form field state with the usage of `GlobalKey`.
* Retrieve the initial state of the file form field if appropriate properties are passed (it has initial value and initial file value handler is not `null`).


For future reference, we would need to set the correct initial file value handler in our app like so:

```dart
...
JsonForm(
...
          initialFileValueHandler: () => {"*": _defaultInitialFileValueHandler},
...

Future<List<SchemaFormFile>?> _defaultInitialFileValueHandler(
  dynamic defaultValue,
) async {
  Future<SchemaFormFile?> schemaFileFromUrl(String ref) async {
    final storageRef = FirebaseStorage.instance.ref();
    final pathReference = storageRef.child(ref);
    final bytes = await pathReference.getData();
    return SchemaFormFile(name: ref.split('/').last, value: ref, bytes: bytes!);
  }

  if (defaultValue is List) {
    final result =
        await Future.wait(defaultValue.cast<String>().map(schemaFileFromUrl));
    return result.whereType<SchemaFormFile>().toList();
  }

  if (defaultValue is String) {
    final file = await schemaFileFromUrl(defaultValue);
    if (file != null) return [file];
  }

  return null;
}
``` 
### Screenshots

<img width="433" alt="Screenshot 2023-08-09 at 10 56 17 AM" src="https://github.com/doneservices/flutter_jsonschema_builder/assets/44665622/608b1d09-e6d0-4e42-8ab8-71113070cedc">

<img width="479" alt="Screenshot 2023-08-09 at 11 56 42 AM" src="https://github.com/doneservices/flutter_jsonschema_builder/assets/44665622/cd9a5ce4-77ee-44c1-b1fd-79e978a8cbdf">
