### PR TITLE
Support multiple file fields

### DIFF
--- a/lib/src/fields/file_form_field.dart
+++ b/lib/src/fields/file_form_field.dart
@@ -17,17 +17,17 @@ class FileJFormField extends PropertyFieldWidget<dynamic> {
     this.initialFileValueHandler,
     final String? Function(dynamic)? customValidator,
   }) : super(
-          key: key,
-          property: property,
-          onSaved: onSaved,
-          onChanged: onChanged,
-          customValidator: customValidator,
-        );
+         key: key,
+         property: property,
+         onSaved: onSaved,
+         onChanged: onChanged,
+         customValidator: customValidator,
+       );
 
   final Future<List<SchemaFormFile>?> Function(SchemaProperty property)
-      fileHandler;
+  fileHandler;
   final Future<List<SchemaFormFile>?> Function(dynamic initialValue)?
-      initialFileValueHandler;
+  initialFileValueHandler;
 
   @override
   _FileJFormFieldState createState() => _FileJFormFieldState();
@@ -77,9 +77,14 @@ class _FileJFormFieldState extends State<FileJFormField> {
             FieldHeader(property: widget.property),
             const SizedBox(height: 10),
             if (filesBuilder != null)
-              filesBuilder(field.value,
-                  onRemove: (name) => change(field.value!
-                    ..removeWhere((element) => element.name == name))),
+              filesBuilder(
+                field.value,
+                onRemove: (name) => change(
+                  field.value
+                      ?.where((element) => !_matchesFile(element, name))
+                      .toList(),
+                ),
+              ),
             _buildButton(widgetBuilderInherited),
             if (filesBuilder == null) ...[
               const SizedBox(height: 10),
@@ -91,20 +96,24 @@ class _FileJFormFieldState extends State<FileJFormField> {
                   final currentFile = field.value![index];
                   final name = currentFile.name;
                   return ListTile(
-                    title: Text(name,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: widget.property.readOnly
-                            ? Theme.of(context)
-                                .textTheme
-                                .titleMedium!
-                                .apply(color: Colors.grey)
-                            : Theme.of(context).textTheme.titleMedium),
+                    title: Text(
+                      name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: widget.property.readOnly
+                          ? Theme.of(
+                              context,
+                            ).textTheme.titleMedium!.apply(color: Colors.grey)
+                          : Theme.of(context).textTheme.titleMedium,
+                    ),
                     trailing: IconButton(
                       icon: const Icon(Icons.close, size: 14),
                       onPressed: () {
-                        change(field.value!
-                          ..removeWhere((element) => element.name == name));
+                        change(
+                          field.value
+                              ?.where((element) => !_matchesFile(element, name))
+                              .toList(),
+                        );
                       },
                     ),
                   );
@@ -119,13 +128,15 @@ class _FileJFormFieldState extends State<FileJFormField> {
   }
 
   Future<void> _triggerInitialValue() async {
-    final shouldTrigger = !hasTriggeredInitialValue &&
+    final shouldTrigger =
+        !hasTriggeredInitialValue &&
         widget.initialFileValueHandler != null &&
         widget.property.defaultValue != null;
     if (shouldTrigger) {
       hasTriggeredInitialValue = true;
-      final initialValue =
-          await widget.initialFileValueHandler!(widget.property.defaultValue);
+      final initialValue = await widget.initialFileValueHandler!(
+        widget.property.defaultValue,
+      );
       SchedulerBinding.instance.addPostFrameCallback((_) {
         change(initialValue);
       });
@@ -149,8 +160,15 @@ class _FileJFormFieldState extends State<FileJFormField> {
     final result = await widget.fileHandler(widget.property);
 
     if (result != null) {
-      change(result);
+      final nextValue = widget.property.isMultipleFile
+          ? [...?_fieldKey.currentState?.value, ...result]
+          : result;
+      change(nextValue);
     }
+  }
+
+  bool _matchesFile(SchemaFormFile file, String identifier) {
+    return file.value == identifier || file.name == identifier;
   }
 
   Widget _buildButton(WidgetBuilderInherited widgetBuilderInherited) {

--- a/lib/src/models/array_schema.dart
+++ b/lib/src/models/array_schema.dart
@@ -13,25 +13,31 @@ class SchemaArray extends Schema {
     required String id,
     required this.itemsBaseSchema,
     String? title,
+    String? description,
+    this.defaultValue,
     this.minItems,
     this.maxItems,
     this.uniqueItems = true,
     this.items = const [],
     this.required = false,
   }) : super(
-          id: id,
-          title: title ?? 'no-title',
-          type: SchemaType.array,
-        );
+         id: id,
+         title: title ?? 'no-title',
+         description: description,
+         type: SchemaType.array,
+       );
 
   factory SchemaArray.fromJson(
     String id,
     Map<String, dynamic> json, {
     Schema? parent,
+    Map<String, dynamic>? initialData,
   }) {
     final schemaArray = SchemaArray(
       id: id,
       title: json['title'],
+      description: json['description'],
+      defaultValue: initialData?[id] ?? json['default'],
       minItems: json['minItems'],
       maxItems: json['maxItems'],
       uniqueItems: json['uniqueItems'] ?? true,
@@ -49,25 +55,29 @@ class SchemaArray extends Schema {
     String? parentIdKey,
     List<String>? dependentsAddedBy,
   }) {
-    var newSchema = SchemaArray(
-      id: id,
-      title: title,
-      maxItems: maxItems,
-      minItems: minItems,
-      uniqueItems: uniqueItems,
-      itemsBaseSchema: itemsBaseSchema,
-      required: required,
-    )
-      ..parentIdKey = parentIdKey ?? this.parentIdKey
-      ..dependentsAddedBy = dependentsAddedBy ?? this.dependentsAddedBy
-      ..type = type;
+    var newSchema =
+        SchemaArray(
+            id: id,
+            title: title,
+            maxItems: maxItems,
+            minItems: minItems,
+            uniqueItems: uniqueItems,
+            itemsBaseSchema: itemsBaseSchema,
+            defaultValue: defaultValue,
+            required: required,
+          )
+          ..parentIdKey = parentIdKey ?? this.parentIdKey
+          ..dependentsAddedBy = dependentsAddedBy ?? this.dependentsAddedBy
+          ..type = type;
 
     newSchema.items = items
-        .map((e) => e.copyWith(
-              id: e.id,
-              parentIdKey: newSchema.idKey,
-              dependentsAddedBy: newSchema.dependentsAddedBy,
-            ))
+        .map(
+          (e) => e.copyWith(
+            id: e.id,
+            parentIdKey: newSchema.idKey,
+            dependentsAddedBy: newSchema.dependentsAddedBy,
+          ),
+        )
         .toList();
 
     return newSchema;
@@ -78,6 +88,7 @@ class SchemaArray extends Schema {
 
   // it allow us
   dynamic itemsBaseSchema;
+  dynamic defaultValue;
 
   int? minItems;
   int? maxItems;
@@ -93,13 +104,14 @@ class SchemaArray extends Schema {
 
   SchemaProperty toSchemaPropertyMultipleFiles() {
     return SchemaProperty(
-      id: id,
-      title: title,
-      type: SchemaType.string,
-      format: PropertyFormat.dataurl,
-      required: required,
-      description: description,
-    )
+        id: id,
+        title: title,
+        type: SchemaType.string,
+        format: PropertyFormat.dataurl,
+        required: required,
+        description: description,
+        defaultValue: defaultValue,
+      )
       ..parentIdKey = parentIdKey
       ..dependentsAddedBy = dependentsAddedBy
       ..isMultipleFile = true;

--- a/lib/src/models/array_schema.dart
+++ b/lib/src/models/array_schema.dart
@@ -21,11 +21,11 @@ class SchemaArray extends Schema {
     this.items = const [],
     this.required = false,
   }) : super(
-         id: id,
-         title: title ?? 'no-title',
-         description: description,
-         type: SchemaType.array,
-       );
+          id: id,
+          title: title ?? 'no-title',
+          description: description,
+          type: SchemaType.array,
+        );
 
   factory SchemaArray.fromJson(
     String id,
@@ -55,20 +55,19 @@ class SchemaArray extends Schema {
     String? parentIdKey,
     List<String>? dependentsAddedBy,
   }) {
-    var newSchema =
-        SchemaArray(
-            id: id,
-            title: title,
-            maxItems: maxItems,
-            minItems: minItems,
-            uniqueItems: uniqueItems,
-            itemsBaseSchema: itemsBaseSchema,
-            defaultValue: defaultValue,
-            required: required,
-          )
-          ..parentIdKey = parentIdKey ?? this.parentIdKey
-          ..dependentsAddedBy = dependentsAddedBy ?? this.dependentsAddedBy
-          ..type = type;
+    var newSchema = SchemaArray(
+      id: id,
+      title: title,
+      description: description,
+      maxItems: maxItems,
+      minItems: minItems,
+      uniqueItems: uniqueItems,
+      itemsBaseSchema: itemsBaseSchema,
+      defaultValue: defaultValue,
+      required: required,
+    )
+      ..parentIdKey = parentIdKey ?? this.parentIdKey
+      ..dependentsAddedBy = dependentsAddedBy ?? this.dependentsAddedBy;
 
     newSchema.items = items
         .map(
@@ -104,14 +103,14 @@ class SchemaArray extends Schema {
 
   SchemaProperty toSchemaPropertyMultipleFiles() {
     return SchemaProperty(
-        id: id,
-        title: title,
-        type: SchemaType.string,
-        format: PropertyFormat.dataurl,
-        required: required,
-        description: description,
-        defaultValue: defaultValue,
-      )
+      id: id,
+      title: title,
+      type: SchemaType.string,
+      format: PropertyFormat.dataurl,
+      required: required,
+      description: description,
+      defaultValue: defaultValue,
+    )
       ..parentIdKey = parentIdKey
       ..dependentsAddedBy = dependentsAddedBy
       ..isMultipleFile = true;

--- a/lib/src/models/schema.dart
+++ b/lib/src/models/schema.dart
@@ -10,14 +10,14 @@ SchemaType schemaTypeFromString(String value) {
 }
 
 class Schema {
-  Schema(
-      {required this.id,
-      required this.type,
-      this.title = 'no-title',
-      this.description,
-      this.parentIdKey,
-      List<String>? dependentsAddedBy})
-      : dependentsAddedBy = dependentsAddedBy ?? [];
+  Schema({
+    required this.id,
+    required this.type,
+    this.title = 'no-title',
+    this.description,
+    this.parentIdKey,
+    List<String>? dependentsAddedBy,
+  }) : dependentsAddedBy = dependentsAddedBy ?? [];
 
   factory Schema.fromJson(
     Map<String, dynamic> json, {
@@ -27,7 +27,7 @@ class Schema {
   }) {
     Schema schema;
 
-// Solucion temporal y personalizada
+    // Solucion temporal y personalizada
     if (json['enum'] != null &&
         json['enum'] is List<String> &&
         json['enum'].length == 1) {
@@ -48,7 +48,12 @@ class Schema {
         break;
 
       case SchemaType.array:
-        schema = SchemaArray.fromJson(id, json, parent: parent);
+        schema = SchemaArray.fromJson(
+          id,
+          json,
+          parent: parent,
+          initialData: initialData,
+        );
 
         // validate if is a file array, it means multiplefile
         if (schema is SchemaArray && schema.isArrayMultipleFile())
@@ -110,11 +115,7 @@ class Schema {
 // Solucion temporal y personalizada
 class SchemaEnum extends Schema {
   SchemaEnum({required this.enumm})
-      : super(
-          id: kNoIdKey,
-          title: 'no-title',
-          type: SchemaType.enumm,
-        );
+    : super(id: kNoIdKey, title: 'no-title', type: SchemaType.enumm);
 
   final List<String> enumm;
 }

--- a/test/file_form_field_test.dart
+++ b/test/file_form_field_test.dart
@@ -1,0 +1,159 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_jsonschema_builder/flutter_jsonschema_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('multiple file field appends new selections', (tester) async {
+    var pickCount = 0;
+    dynamic latestData;
+    dynamic savedData;
+
+    await tester.pumpWidget(
+      _TestApp(
+        form: JsonForm(
+          jsonSchema: json.encode(_schemaWithMultipleFiles),
+          initialData: Map<String, dynamic>.of(const {}),
+          onChanged: (data) => latestData = Map<String, dynamic>.from(data),
+          onFormDataSaved: (data) {
+            savedData = Map<String, dynamic>.from(data as Map);
+          },
+          fileHandler: () => {
+            '*': (_) async {
+              pickCount++;
+              return [
+                SchemaFormFile(
+                  name: 'file-$pickCount.jpg',
+                  value: 'stored-file-$pickCount.jpg',
+                  bytes: Uint8List(0),
+                ),
+              ];
+            },
+          },
+          jsonFormSchemaUiConfig: JsonFormSchemaUiConfig(
+            addFileButtonBuilder: (onPressed, _) {
+              return ElevatedButton(
+                onPressed: onPressed,
+                child: const Text('Add file'),
+              );
+            },
+            submitButtonBuilder: (onSubmit) {
+              return ElevatedButton(
+                onPressed: onSubmit,
+                child: const Text('Submit'),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Add file'));
+    await tester.pumpAndSettle();
+
+    expect(latestData, {
+      'files': ['stored-file-1.jpg'],
+    });
+    expect(find.text('file-1.jpg'), findsOneWidget);
+
+    await tester.tap(find.text('Add file'));
+    await tester.pumpAndSettle();
+
+    expect(latestData, {
+      'files': ['stored-file-1.jpg', 'stored-file-2.jpg'],
+    });
+    expect(find.text('file-1.jpg'), findsOneWidget);
+    expect(find.text('file-2.jpg'), findsOneWidget);
+
+    await tester.tap(find.text('Submit'));
+    await tester.pumpAndSettle();
+
+    expect(savedData, {
+      'files': ['stored-file-1.jpg', 'stored-file-2.jpg'],
+    });
+  });
+
+  testWidgets('multiple file field hydrates array initial data', (
+    tester,
+  ) async {
+    dynamic handlerValue;
+    List<SchemaFormFile>? renderedFiles;
+
+    await tester.pumpWidget(
+      _TestApp(
+        form: JsonForm(
+          jsonSchema: json.encode(_schemaWithMultipleFiles),
+          initialData: Map<String, dynamic>.of({
+            'files': List<String>.of(const [
+              'stored-file-1.jpg',
+              'stored-file-2.jpg',
+            ]),
+          }),
+          onFormDataSaved: (_) {},
+          fileHandler: () => {'*': (_) async => const []},
+          initialFileValueHandler: () => {
+            '*': (value) async {
+              handlerValue = value;
+              return (value as List)
+                  .cast<String>()
+                  .map(
+                    (file) => SchemaFormFile(
+                      name: file,
+                      value: file,
+                      bytes: Uint8List(0),
+                    ),
+                  )
+                  .toList();
+            },
+          },
+          jsonFormSchemaUiConfig: JsonFormSchemaUiConfig(
+            addFileButtonBuilder: (_, __) => const SizedBox.shrink(),
+            filesBuilder: (files, {required onRemove}) {
+              renderedFiles = files;
+              return Column(
+                children: [
+                  for (final file in files ?? <SchemaFormFile>[])
+                    Text(file.name),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(handlerValue, ['stored-file-1.jpg', 'stored-file-2.jpg']);
+    expect(renderedFiles?.map((file) => file.value), [
+      'stored-file-1.jpg',
+      'stored-file-2.jpg',
+    ]);
+    expect(find.text('stored-file-1.jpg'), findsOneWidget);
+    expect(find.text('stored-file-2.jpg'), findsOneWidget);
+  });
+}
+
+const _schemaWithMultipleFiles = {
+  'type': 'object',
+  'properties': {
+    'files': {
+      'type': 'array',
+      'title': 'Files',
+      'items': {'type': 'string', 'format': 'data-url'},
+    },
+  },
+};
+
+class _TestApp extends StatelessWidget {
+  const _TestApp({required this.form});
+
+  final Widget form;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(home: Scaffold(body: form));
+  }
+}

--- a/test/file_form_field_test.dart
+++ b/test/file_form_field_test.dart
@@ -10,12 +10,13 @@ void main() {
     var pickCount = 0;
     dynamic latestData;
     dynamic savedData;
+    final initialData = <String, dynamic>{};
 
     await tester.pumpWidget(
       _TestApp(
         form: JsonForm(
           jsonSchema: json.encode(_schemaWithMultipleFiles),
-          initialData: Map<String, dynamic>.of(const {}),
+          initialData: initialData,
           onChanged: (data) => latestData = Map<String, dynamic>.from(data),
           onFormDataSaved: (data) {
             savedData = Map<String, dynamic>.from(data as Map);
@@ -80,17 +81,18 @@ void main() {
   ) async {
     dynamic handlerValue;
     List<SchemaFormFile>? renderedFiles;
+    final initialData = <String, dynamic>{
+      'files': <String>[
+        'stored-file-1.jpg',
+        'stored-file-2.jpg',
+      ],
+    };
 
     await tester.pumpWidget(
       _TestApp(
         form: JsonForm(
           jsonSchema: json.encode(_schemaWithMultipleFiles),
-          initialData: Map<String, dynamic>.of({
-            'files': List<String>.of(const [
-              'stored-file-1.jpg',
-              'stored-file-2.jpg',
-            ]),
-          }),
+          initialData: initialData,
           onFormDataSaved: (_) {},
           fileHandler: () => {'*': (_) async => const []},
           initialFileValueHandler: () => {


### PR DESCRIPTION
## Summary
- append new selections for multiple file fields instead of replacing existing files
- preserve array initial data when converting data-url arrays into multiple file properties
- remove selected files by stored value or display name without mutating the existing field list
- add widget tests for appending multiple files and hydrating array initial data

## Verification
- `fvm flutter test test/file_form_field_test.dart`
- `fvm dart analyze lib/src/fields/file_form_field.dart lib/src/models/array_schema.dart lib/src/models/schema.dart test/file_form_field_test.dart`

Note: full `fvm dart analyze` still reports pre-existing warnings in dropdown/radio fields outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable file add/remove behavior in file form fields using unified matching and immutable list updates.

* **New Features**
  * Array schemas now support descriptions and default values, with initial-data-aware construction.

* **Tests**
  * Added end-to-end widget tests for multiple-file form fields covering initial hydration, add flows, rendering, and form submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->