### PR TITLE
Stepped-mode UX: enum radios, auto-advance, ui:group, keyboard navigation

### DIFF
--- a/lib/src/builder/field_header_widget.dart
+++ b/lib/src/builder/field_header_widget.dart
@@ -1,26 +1,36 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_jsonschema_builder/flutter_jsonschema_builder.dart';
+import 'package:flutter_jsonschema_builder/src/builder/stepped_form_builder.dart';
 
 class FieldHeader extends StatelessWidget {
-  const FieldHeader({required this.property, Key? key}) : super(key: key);
+  const FieldHeader({required this.property, this.showTitle = true, super.key});
   final SchemaProperty property;
+
+  /// `false` when the field renders the title itself (e.g. as a checkbox
+  /// label), so it isn't shown twice
+  final bool showTitle;
+
   @override
   Widget build(BuildContext context) {
     final description = property.description;
+    // stepped mode breathes more: the header doubles as the step's heading
+    final isStepped = SteppedFormScope.maybeOf(context) != null;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Text(
-          '${property.title} ${property.required ? "*" : ""}',
-          style: Theme.of(context).textTheme.bodyMedium,
-        ),
+        if (showTitle)
+          Text(
+            '${property.title} ${property.required ? "*" : ""}',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
         if (description != null && description.isNotEmpty) ...[
           const SizedBox(height: 4),
           Text(
             description,
             style: Theme.of(context).textTheme.bodySmall,
           ),
-        ]
+        ],
+        if (isStepped) const SizedBox(height: 12),
       ],
     );
   }

--- a/lib/src/builder/logic/widget_builder_logic.dart
+++ b/lib/src/builder/logic/widget_builder_logic.dart
@@ -7,20 +7,21 @@ import 'package:flutter_jsonschema_builder/src/models/schema.dart';
 
 class WidgetBuilderInherited extends InheritedWidget {
   WidgetBuilderInherited({
-    Key? key,
+    super.key,
     required this.mainSchema,
-    required Widget child,
+    required super.child,
     this.fileHandler,
     this.initialFileValueHandler,
     this.customPickerHandler,
     this.customValidatorHandler,
     this.onChanged,
     this.inputDecoration,
+    this.displayMode = JsonFormDisplayMode.fullForm,
     Map<String, dynamic>? initialData,
-  })  : data = initialData ?? {},
-        super(key: key, child: child);
+  })  : data = initialData ?? {};
 
   final Schema mainSchema;
+  final JsonFormDisplayMode displayMode;
   final Map<String, dynamic> data;
 
   final FileHandler? fileHandler;
@@ -54,39 +55,39 @@ class WidgetBuilderInherited extends InheritedWidget {
     final stack = path.split('.');
 
     while (stack.length > 1) {
-      final _key = stack[0];
+      final key = stack[0];
       final isNextKeyInteger = int.tryParse(stack[1]) != null;
       final newContent = isNextKeyInteger ? [] : {};
-      final _keyNumeric = int.tryParse(_key);
+      final keyNumeric = int.tryParse(key);
 
-      log('$_key - next Key is int? $isNextKeyInteger');
+      log('$key - next Key is int? $isNextKeyInteger');
 
-      _addNewContent(object, _keyNumeric, newContent);
+      _addNewContent(object, keyNumeric, newContent);
 
-      final tempObject = object[_keyNumeric ?? _key];
+      final tempObject = object[keyNumeric ?? key];
       if (tempObject != null) {
         object = tempObject;
       } else {
-        object[_key] = newContent;
-        object = object[_key];
+        object[key] = newContent;
+        object = object[key];
       }
 
       stack.removeAt(0);
     }
 
-    final _key = stack[0];
-    final _keyNumeric = int.tryParse(_key);
-    _addNewContent(object, _keyNumeric, value);
+    final key = stack[0];
+    final keyNumeric = int.tryParse(key);
+    _addNewContent(object, keyNumeric, value);
 
-    object[_keyNumeric ?? _key] = value;
+    object[keyNumeric ?? key] = value;
     stack.removeAt(0);
     onChanged?.call(data);
   }
 
   /// add a new value into a schema,
-  void _addNewContent(object, int? _keyNumeric, dynamic value) {
-    if (object is List && _keyNumeric != null) {
-      if (object.length - 1 < _keyNumeric) {
+  void _addNewContent(object, int? keyNumeric, dynamic value) {
+    if (object is List && keyNumeric != null) {
+      if (object.length - 1 < keyNumeric) {
         object.add(value);
       }
     }

--- a/lib/src/builder/property_schema_builder.dart
+++ b/lib/src/builder/property_schema_builder.dart
@@ -169,8 +169,9 @@ class PropertySchemaBuilder extends StatelessWidget {
                 context,
                 schemaProperty.idKey,
               ),
-              decoration:
-                  WidgetBuilderInherited.of(context).uiConfig.inputDecoration,
+              decoration: WidgetBuilderInherited.of(
+                context,
+              ).uiConfig.inputDecoration,
             );
             break;
           }
@@ -211,8 +212,9 @@ class PropertySchemaBuilder extends StatelessWidget {
                 context,
                 schemaProperty.idKey,
               ),
-              decoration:
-                  WidgetBuilderInherited.of(context).uiConfig.inputDecoration,
+              decoration: WidgetBuilderInherited.of(
+                context,
+              ).uiConfig.inputDecoration,
             );
             break;
           }
@@ -229,8 +231,9 @@ class PropertySchemaBuilder extends StatelessWidget {
               widgetBuilderInherited.notifyChanges();
             },
             customValidator: _getCustomValidator(context, schemaProperty.idKey),
-            decoration:
-                WidgetBuilderInherited.of(context).uiConfig.inputDecoration,
+            decoration: WidgetBuilderInherited.of(
+              context,
+            ).uiConfig.inputDecoration,
           );
           break;
         case SchemaType.integer:
@@ -250,54 +253,30 @@ class PropertySchemaBuilder extends StatelessWidget {
               widgetBuilderInherited.notifyChanges();
             },
             customValidator: _getCustomValidator(context, schemaProperty.idKey),
-            decoration:
-                WidgetBuilderInherited.of(context).uiConfig.inputDecoration,
+            decoration: WidgetBuilderInherited.of(
+              context,
+            ).uiConfig.inputDecoration,
           );
           break;
         case SchemaType.boolean:
-          if (schemaProperty.widget == 'radio') {
-            field = RadioButtonJFormField(
-              property: schemaPropertySorted,
-              onChanged: (value) {
-                dispatchBooleanEventToParent(context, value != null);
-                updateData(context, value);
-                widgetBuilderInherited.notifyChanges();
-              },
-              onSaved: (val) {
-                log(
-                  'onSaved: RadioButtonJFormField ${schemaProperty.idKey}  : $val',
-                );
+          // ui:widget radio booleans never reach this switch — the useRadio
+          // branch above already handled them
+          field = CheckboxJFormField(
+            property: schemaPropertySorted,
+            onChanged: (value) {
+              dispatchBooleanEventToParent(context, value!);
+              updateData(context, value);
+              widgetBuilderInherited.notifyChanges();
+            },
+            onSaved: (val) {
+              log(
+                'onSaved: CheckboxJFormField ${schemaProperty.idKey}  : $val',
+              );
 
-                updateData(context, val);
-              },
-              customValidator: _getCustomValidator(
-                context,
-                schemaProperty.idKey,
-              ),
-              decoration:
-                  WidgetBuilderInherited.of(context).uiConfig.inputDecoration,
-            );
-          } else {
-            field = CheckboxJFormField(
-              property: schemaPropertySorted,
-              onChanged: (value) {
-                dispatchBooleanEventToParent(context, value!);
-                updateData(context, value);
-                widgetBuilderInherited.notifyChanges();
-              },
-              onSaved: (val) {
-                log(
-                  'onSaved: CheckboxJFormField ${schemaProperty.idKey}  : $val',
-                );
-
-                updateData(context, val);
-              },
-              customValidator: _getCustomValidator(
-                context,
-                schemaProperty.idKey,
-              ),
-            );
-          }
+              updateData(context, val);
+            },
+            customValidator: _getCustomValidator(context, schemaProperty.idKey),
+          );
 
           break;
         default:
@@ -313,8 +292,9 @@ class PropertySchemaBuilder extends StatelessWidget {
               widgetBuilderInherited.notifyChanges();
             },
             customValidator: _getCustomValidator(context, schemaProperty.idKey),
-            decoration:
-                WidgetBuilderInherited.of(context).uiConfig.inputDecoration,
+            decoration: WidgetBuilderInherited.of(
+              context,
+            ).uiConfig.inputDecoration,
           );
       }
     }
@@ -435,8 +415,9 @@ class PropertySchemaBuilder extends StatelessWidget {
     BuildContext context,
     String key,
   ) {
-    final customPickerHandler =
-        WidgetBuilderInherited.of(context).customPickerHandler;
+    final customPickerHandler = WidgetBuilderInherited.of(
+      context,
+    ).customPickerHandler;
 
     if (customPickerHandler == null) return null;
 
@@ -453,8 +434,9 @@ class PropertySchemaBuilder extends StatelessWidget {
     BuildContext context,
     String key,
   ) {
-    final customValidatorHandler =
-        WidgetBuilderInherited.of(context).customValidatorHandler;
+    final customValidatorHandler = WidgetBuilderInherited.of(
+      context,
+    ).customValidatorHandler;
 
     if (customValidatorHandler == null) return null;
 

--- a/lib/src/builder/property_schema_builder.dart
+++ b/lib/src/builder/property_schema_builder.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_jsonschema_builder/src/builder/logic/object_schema_logic.dart';
 import 'package:flutter_jsonschema_builder/src/builder/logic/widget_builder_logic.dart';
+import 'package:flutter_jsonschema_builder/src/builder/stepped_form_builder.dart';
 import 'package:flutter_jsonschema_builder/src/builder/widget_builder.dart';
 import 'package:flutter_jsonschema_builder/src/fields/fields.dart';
 import 'package:flutter_jsonschema_builder/src/fields/radio_button_form_field.dart';
@@ -16,12 +17,12 @@ import 'package:intl/intl.dart';
 
 class PropertySchemaBuilder extends StatelessWidget {
   const PropertySchemaBuilder({
-    Key? key,
+    super.key,
     required this.mainSchema,
     required this.schemaProperty,
     this.showDebugElements = true,
     this.onChangeListen,
-  }) : super(key: key);
+  });
   final Schema mainSchema;
   final SchemaProperty schemaProperty;
   final ValueChanged<dynamic>? onChangeListen;
@@ -29,19 +30,43 @@ class PropertySchemaBuilder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Widget _field = const SizedBox.shrink();
+    Widget field = const SizedBox.shrink();
     final widgetBuilderInherited = WidgetBuilderInherited.of(context);
 
     // sort
     final schemaPropertySorted = schemaProperty;
 
-    if (schemaProperty.widget == 'radio') {
-      _field = RadioButtonJFormField(
+    final hasEnum =
+        schemaProperty.enumm != null &&
+        (schemaProperty.enumm!.isNotEmpty ||
+            (schemaProperty.enumNames != null &&
+                schemaProperty.enumNames!.isNotEmpty));
+    // In stepped mode, enums default to radio unless a widget is set explicitly.
+    final useRadio =
+        schemaProperty.widget == 'radio' ||
+        (hasEnum &&
+            schemaProperty.widget == null &&
+            widgetBuilderInherited.displayMode == JsonFormDisplayMode.stepped);
+
+    if (useRadio) {
+      field = RadioButtonJFormField(
         property: schemaPropertySorted,
         onChanged: (value) {
-          dispatchBooleanEventToParent(context, value != null);
+          // enum radios must resolve value-based (oneOf) dependencies just
+          // like the dropdown; the boolean event only handles presence
+          if (hasEnum) {
+            dispatchSelectedForDropDownEventToParent(
+              context,
+              value,
+              id: schemaProperty.id,
+            );
+          } else {
+            dispatchBooleanEventToParent(context, value != null);
+          }
           updateData(context, value);
           widgetBuilderInherited.notifyChanges();
+          if (value != null)
+            SteppedFormScope.maybeOf(context)?.requestAutoAdvance();
         },
         onSaved: (val) {
           log('onSaved: RadioButtonJFormField ${schemaProperty.idKey}  : $val');
@@ -51,11 +76,8 @@ class PropertySchemaBuilder extends StatelessWidget {
         customValidator: _getCustomValidator(context, schemaProperty.idKey),
         decoration: WidgetBuilderInherited.of(context).uiConfig.inputDecoration,
       );
-    } else if (schemaProperty.enumm != null &&
-        (schemaProperty.enumm!.isNotEmpty ||
-            (schemaProperty.enumNames != null &&
-                schemaProperty.enumNames!.isNotEmpty))) {
-      _field = DropDownJFormField(
+    } else if (hasEnum) {
+      field = DropDownJFormField(
         property: schemaPropertySorted,
         customPickerHandler: _getCustomPickerHanlder(
           context,
@@ -66,16 +88,21 @@ class PropertySchemaBuilder extends StatelessWidget {
           updateData(context, val);
         },
         onChanged: (value) {
-          dispatchSelectedForDropDownEventToParent(context, value,
-              id: schemaProperty.id);
+          dispatchSelectedForDropDownEventToParent(
+            context,
+            value,
+            id: schemaProperty.id,
+          );
           updateData(context, value);
           widgetBuilderInherited.notifyChanges();
+          if (value != null)
+            SteppedFormScope.maybeOf(context)?.requestAutoAdvance();
         },
         customValidator: _getCustomValidator(context, schemaProperty.idKey),
         decoration: WidgetBuilderInherited.of(context).uiConfig.inputDecoration,
       );
     } else if (schemaProperty.oneOf != null) {
-      _field = DropdownOneOfJFormField(
+      field = DropdownOneOfJFormField(
         property: schemaPropertySorted,
         customPickerHandler: _getCustomPickerHanlder(
           context,
@@ -83,13 +110,18 @@ class PropertySchemaBuilder extends StatelessWidget {
         ),
         onSaved: (val) {
           if (val is OneOfModel) {
-            log('onSaved: SelectedFormField  ${schemaProperty.idKey}  : ${val.oneOfModelEnum?.first}');
+            log(
+              'onSaved: SelectedFormField  ${schemaProperty.idKey}  : ${val.oneOfModelEnum?.first}',
+            );
             updateData(context, val.oneOfModelEnum?.first);
           }
         },
         onChanged: (value) {
-          dispatchSelectedForDropDownEventToParent(context, value,
-              id: schemaProperty.id);
+          dispatchSelectedForDropDownEventToParent(
+            context,
+            value,
+            id: schemaProperty.id,
+          );
 
           if (value is OneOfModel) {
             updateData(context, value.oneOfModelEnum?.first);
@@ -104,7 +136,7 @@ class PropertySchemaBuilder extends StatelessWidget {
         case SchemaType.string:
           if (schemaProperty.format == PropertyFormat.date ||
               schemaProperty.format == PropertyFormat.datetime) {
-            _field = DateJFormField(
+            field = DateJFormField(
               property: schemaPropertySorted,
               onSaved: (val) {
                 if (val == null) return;
@@ -115,7 +147,9 @@ class PropertySchemaBuilder extends StatelessWidget {
                   date = DateFormat(dateTimeFormatString).format(val);
                 }
 
-                log('onSaved: DateJFormField  ${schemaProperty.idKey}  : $date');
+                log(
+                  'onSaved: DateJFormField  ${schemaProperty.idKey}  : $date',
+                );
                 updateData(context, date);
               },
               onChanged: (value) {
@@ -131,8 +165,10 @@ class PropertySchemaBuilder extends StatelessWidget {
                 updateData(context, date);
                 widgetBuilderInherited.notifyChanges();
               },
-              customValidator:
-                  _getCustomValidator(context, schemaProperty.idKey),
+              customValidator: _getCustomValidator(
+                context,
+                schemaProperty.idKey,
+              ),
               decoration:
                   WidgetBuilderInherited.of(context).uiConfig.inputDecoration,
             );
@@ -140,16 +176,20 @@ class PropertySchemaBuilder extends StatelessWidget {
           }
 
           if (schemaProperty.format == PropertyFormat.dataurl) {
-            assert(WidgetBuilderInherited.of(context).fileHandler != null,
-                'File handler can not be null when using file inputs');
-            _field = FileJFormField(
+            assert(
+              WidgetBuilderInherited.of(context).fileHandler != null,
+              'File handler can not be null when using file inputs',
+            );
+            field = FileJFormField(
               property: schemaPropertySorted,
               fileHandler: getCustomFileHandler(
-                  WidgetBuilderInherited.of(context).fileHandler!,
-                  schemaProperty.id),
+                WidgetBuilderInherited.of(context).fileHandler!,
+                schemaProperty.id,
+              ),
               initialFileValueHandler: getCustomInitialFileValueHandler(
-                  WidgetBuilderInherited.of(context).initialFileValueHandler,
-                  schemaProperty.id),
+                WidgetBuilderInherited.of(context).initialFileValueHandler,
+                schemaProperty.id,
+              ),
               onSaved: (val) {
                 log('onSaved: FileJFormField  ${schemaProperty.idKey}  : $val');
                 updateData(context, val);
@@ -158,23 +198,26 @@ class PropertySchemaBuilder extends StatelessWidget {
                 print(value);
 
                 dispatchBooleanEventToParent(
-                    context,
-                    schemaProperty.isMultipleFile
-                        ? value is List && value.isNotEmpty
-                        : value != null);
+                  context,
+                  schemaProperty.isMultipleFile
+                      ? value is List && value.isNotEmpty
+                      : value != null,
+                );
 
                 updateData(context, value);
                 widgetBuilderInherited.notifyChanges();
               },
-              customValidator:
-                  _getCustomValidator(context, schemaProperty.idKey),
+              customValidator: _getCustomValidator(
+                context,
+                schemaProperty.idKey,
+              ),
               decoration:
                   WidgetBuilderInherited.of(context).uiConfig.inputDecoration,
             );
             break;
           }
 
-          _field = TextJFormField(
+          field = TextJFormField(
             property: schemaPropertySorted,
             onSaved: (val) {
               log('onSaved: TextJFormField ${schemaProperty.idKey}  : $val');
@@ -192,7 +235,7 @@ class PropertySchemaBuilder extends StatelessWidget {
           break;
         case SchemaType.integer:
         case SchemaType.number:
-          _field = NumberJFormField(
+          field = NumberJFormField(
             property: schemaPropertySorted,
             onSaved: (val) {
               log('onSaved: NumberJFormField ${schemaProperty.idKey}  : $val');
@@ -213,7 +256,7 @@ class PropertySchemaBuilder extends StatelessWidget {
           break;
         case SchemaType.boolean:
           if (schemaProperty.widget == 'radio') {
-            _field = RadioButtonJFormField(
+            field = RadioButtonJFormField(
               property: schemaPropertySorted,
               onChanged: (value) {
                 dispatchBooleanEventToParent(context, value != null);
@@ -221,17 +264,21 @@ class PropertySchemaBuilder extends StatelessWidget {
                 widgetBuilderInherited.notifyChanges();
               },
               onSaved: (val) {
-                log('onSaved: RadioButtonJFormField ${schemaProperty.idKey}  : $val');
+                log(
+                  'onSaved: RadioButtonJFormField ${schemaProperty.idKey}  : $val',
+                );
 
                 updateData(context, val);
               },
-              customValidator:
-                  _getCustomValidator(context, schemaProperty.idKey),
+              customValidator: _getCustomValidator(
+                context,
+                schemaProperty.idKey,
+              ),
               decoration:
                   WidgetBuilderInherited.of(context).uiConfig.inputDecoration,
             );
           } else {
-            _field = CheckboxJFormField(
+            field = CheckboxJFormField(
               property: schemaPropertySorted,
               onChanged: (value) {
                 dispatchBooleanEventToParent(context, value!);
@@ -239,18 +286,22 @@ class PropertySchemaBuilder extends StatelessWidget {
                 widgetBuilderInherited.notifyChanges();
               },
               onSaved: (val) {
-                log('onSaved: CheckboxJFormField ${schemaProperty.idKey}  : $val');
+                log(
+                  'onSaved: CheckboxJFormField ${schemaProperty.idKey}  : $val',
+                );
 
                 updateData(context, val);
               },
-              customValidator:
-                  _getCustomValidator(context, schemaProperty.idKey),
+              customValidator: _getCustomValidator(
+                context,
+                schemaProperty.idKey,
+              ),
             );
           }
 
           break;
         default:
-          _field = TextJFormField(
+          field = TextJFormField(
             property: schemaPropertySorted,
             onSaved: (val) {
               log('onSaved: TextJFormField ${schemaProperty.idKey}  : $val');
@@ -281,7 +332,7 @@ class PropertySchemaBuilder extends StatelessWidget {
               fontWeight: FontWeight.bold,
             ),
           ),
-        _field,
+        field,
       ],
     );
   }
@@ -289,33 +340,41 @@ class PropertySchemaBuilder extends StatelessWidget {
   void updateData(BuildContext context, dynamic val) {
     final widgetBuilderInherited = WidgetBuilderInherited.of(context);
     widgetBuilderInherited.updateObjectData(
-        WidgetBuilderInherited.of(context).data, schemaProperty.idKey, val);
+      WidgetBuilderInherited.of(context).data,
+      schemaProperty.idKey,
+      val,
+    );
   }
 
   // @temp Functions
   /// Cuando se valida si es string o no
   void dispatchStringEventToParent(BuildContext context, String value) {
     if (value.isEmpty && schemaProperty.isDependentsActive) {
-      ObjectSchemaInherited.of(context)
-          .listenChangeProperty(false, schemaProperty);
+      ObjectSchemaInherited.of(
+        context,
+      ).listenChangeProperty(false, schemaProperty);
     }
 
     if (value.isNotEmpty && !schemaProperty.isDependentsActive) {
-      ObjectSchemaInherited.of(context)
-          .listenChangeProperty(true, schemaProperty);
+      ObjectSchemaInherited.of(
+        context,
+      ).listenChangeProperty(true, schemaProperty);
     }
   }
 
   void dispatchSelectedForDropDownEventToParent(
-      BuildContext context, dynamic value,
-      {String? id}) {
+    BuildContext context,
+    dynamic value, {
+    String? id,
+  }) {
     debugPrint('dispatchSelectedForDropDownEventToParent()  $value ID: $id');
     ObjectSchemaInherited.of(context).listenChangeProperty(
-        (value != null && (value is String ? value.isNotEmpty : true)),
-        schemaProperty,
-        optionalValue: value,
-        idOptional: id,
-        mainSchema: mainSchema);
+      (value != null && (value is String ? value.isNotEmpty : true)),
+      schemaProperty,
+      optionalValue: value,
+      idOptional: id,
+      mainSchema: mainSchema,
+    );
     // }
   }
 
@@ -323,32 +382,33 @@ class PropertySchemaBuilder extends StatelessWidget {
   void dispatchBooleanEventToParent(BuildContext context, bool value) {
     debugPrint('dispatchBooleanEventToParent()  $value');
     if (value != schemaProperty.isDependentsActive) {
-      ObjectSchemaInherited.of(context)
-          .listenChangeProperty(value, schemaProperty);
+      ObjectSchemaInherited.of(
+        context,
+      ).listenChangeProperty(value, schemaProperty);
     }
   }
 
   Future<List<SchemaFormFile>?> Function(SchemaProperty property)
-      getCustomFileHandler(FileHandler customFileHandler, String key) {
+  getCustomFileHandler(FileHandler customFileHandler, String key) {
     final handlers = customFileHandler();
     assert(handlers.isNotEmpty, 'CustomFileHandler must not be empty');
 
     if (handlers.containsKey(key)) {
-      return handlers[key] as Future<List<SchemaFormFile>?> Function(
-          SchemaProperty);
+      return handlers[key]
+          as Future<List<SchemaFormFile>?> Function(SchemaProperty);
     }
 
     if (handlers.containsKey('*')) {
       assert(handlers['*'] != null, 'Default file handler must not be null');
-      return handlers['*'] as Future<List<SchemaFormFile>?> Function(
-          SchemaProperty);
+      return handlers['*']
+          as Future<List<SchemaFormFile>?> Function(SchemaProperty);
     }
 
     throw Exception('no file handler found');
   }
 
   Future<List<SchemaFormFile>?> Function(dynamic defaultValue)?
-      getCustomInitialFileValueHandler(
+  getCustomInitialFileValueHandler(
     InitialFileValueHandler? initialFileValueHandler,
     String key,
   ) {
@@ -372,7 +432,9 @@ class PropertySchemaBuilder extends StatelessWidget {
   }
 
   Future<dynamic> Function(SchemaProperty)? _getCustomPickerHanlder(
-      BuildContext context, String key) {
+    BuildContext context,
+    String key,
+  ) {
     final customPickerHandler =
         WidgetBuilderInherited.of(context).customPickerHandler;
 
@@ -388,7 +450,9 @@ class PropertySchemaBuilder extends StatelessWidget {
   }
 
   String? Function(dynamic)? _getCustomValidator(
-      BuildContext context, String key) {
+    BuildContext context,
+    String key,
+  ) {
     final customValidatorHandler =
         WidgetBuilderInherited.of(context).customValidatorHandler;
 

--- a/lib/src/builder/property_schema_builder.dart
+++ b/lib/src/builder/property_schema_builder.dart
@@ -196,8 +196,6 @@ class PropertySchemaBuilder extends StatelessWidget {
                 updateData(context, val);
               },
               onChanged: (value) {
-                print(value);
-
                 dispatchBooleanEventToParent(
                   context,
                   schemaProperty.isMultipleFile

--- a/lib/src/builder/stepped_form_builder.dart
+++ b/lib/src/builder/stepped_form_builder.dart
@@ -98,9 +98,10 @@ class _SteppedFormBuilderState extends State<SteppedFormBuilder> {
       final currentId = _pageId(_currentPage);
       _steps = extractJsonFormSteps(widget.mainSchema);
 
-      var newPage = currentId == _reviewPageId
-          ? _pageCount - 1
-          : _steps.indexWhere((step) => step.id == currentId);
+      var newPage =
+          currentId == _reviewPageId
+              ? _pageCount - 1
+              : _steps.indexWhere((step) => step.id == currentId);
       // the current step may have been removed — or every step (clamping
       // against an empty page range would throw)
       if (newPage < 0) {
@@ -138,6 +139,19 @@ class _SteppedFormBuilderState extends State<SteppedFormBuilder> {
     if (_currentPage > 0) _animateToPage(_currentPage - 1);
   }
 
+  /// called by a field when it receives a value that could advance the form
+  /// (enum selection). Only advances single-field steps so grouped steps
+  /// still wait for the next button; deferred a frame so the field finishes
+  /// its own onChanged (didChange/validate) before the page animates out.
+  void _requestAutoAdvance() {
+    if (!config.autoAdvanceOnSelect || _isTransitioning) return;
+    if (_currentPage >= _steps.length) return;
+    if (_steps[_currentPage].schemas.length != 1) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _goNext();
+    });
+  }
+
   /// every page change funnels through here (including the review page's
   /// tap-to-edit), so this is where re-entrant transitions are blocked
   void _animateToPage(int page) {
@@ -154,9 +168,9 @@ class _SteppedFormBuilderState extends State<SteppedFormBuilder> {
           curve: config.transitionCurve,
         )
         .whenComplete(() {
-      _isTransitioning = false;
-      if (mounted) _syncKeyboardWithPage(page, followFocus);
-    });
+          _isTransitioning = false;
+          if (mounted) _syncKeyboardWithPage(page, followFocus);
+        });
   }
 
   /// the keyboard follows the navigation: when the user was typing, focus
@@ -185,23 +199,42 @@ class _SteppedFormBuilderState extends State<SteppedFormBuilder> {
   /// focus node of the first text field on [page]; null for the review
   /// page, a page without text input, or one that was never built
   FocusNode? _firstTextFieldOn(int page) {
-    if (page >= _steps.length) return null;
-    final formContext = _formKeys[_steps[page].id]?.currentContext;
-    if (formContext == null) return null;
+    final nodes = _textFieldsOn(page);
+    return nodes.isEmpty ? null : nodes.first;
+  }
 
-    FocusNode? node;
+  /// focus nodes of every text field on [page], in visual order; empty for
+  /// the review page or one that was never built
+  List<FocusNode> _textFieldsOn(int page) {
+    if (page >= _steps.length) return const [];
+    final formContext = _formKeys[_steps[page].id]?.currentContext;
+    if (formContext == null) return const [];
+
+    final nodes = <FocusNode>[];
     void visit(Element element) {
-      if (node != null) return;
       final widget = element.widget;
       if (widget is EditableText) {
-        node = widget.focusNode;
+        nodes.add(widget.focusNode);
         return;
       }
       element.visitChildren(visit);
     }
 
     (formContext as Element).visitChildren(visit);
-    return node;
+    return nodes;
+  }
+
+  /// keyboard action button pressed in a text field: move to the next text
+  /// field on the same page, or to the next page when it was the last one
+  void _onTextSubmitted() {
+    if (_isTransitioning) return;
+    final fields = _textFieldsOn(_currentPage);
+    final focusedIndex = fields.indexWhere((node) => node.hasFocus);
+    if (focusedIndex >= 0 && focusedIndex < fields.length - 1) {
+      fields[focusedIndex + 1].requestFocus();
+    } else if (_currentPage < _pageCount - 1) {
+      _goNext();
+    }
   }
 
   /// validates every step, jumping back to the first invalid one. A step
@@ -248,105 +281,162 @@ class _SteppedFormBuilderState extends State<SteppedFormBuilder> {
   @override
   Widget build(BuildContext context) {
     _scheduleControlsMeasurement();
-    return LayoutBuilder(builder: (context, constraints) {
-      assert(
-        constraints.hasBoundedHeight,
-        'JsonForm with JsonFormDisplayMode.stepped expands to fill its parent '
-        'and must be given a bounded height (e.g. via Expanded or SizedBox). '
-        'Do not place it inside an unconstrained scroll view.',
-      );
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        assert(
+          constraints.hasBoundedHeight,
+          'JsonForm with JsonFormDisplayMode.stepped expands to fill its parent '
+          'and must be given a bounded height (e.g. via Expanded or SizedBox). '
+          'Do not place it inside an unconstrained scroll view.',
+        );
 
-      final totalPages = _pageCount > 0 ? _pageCount : 1;
+        final totalPages = _pageCount > 0 ? _pageCount : 1;
 
-      return Padding(
-        padding: widget.padding,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(bottom: 12),
-              child: config.progressBuilder != null
-                  ? config.progressBuilder!(
-                      context, _currentPage + 1, totalPages)
-                  : JsonFormStepProgress(
-                      currentStep: _currentPage + 1,
-                      totalSteps: totalPages,
-                      duration: config.transitionDuration,
-                      curve: config.transitionCurve,
+        return SteppedFormScope(
+          requestAutoAdvance: _requestAutoAdvance,
+          onTextSubmitted: _onTextSubmitted,
+          controlsClearance: _controlsClearance,
+          child: Padding(
+            padding: widget.padding,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // the form's title, like classic mode's header — but smaller,
+                // since here it stays visible on every step
+                if (widget.mainSchema.title != kNoTitle)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: Text(
+                      widget.mainSchema.title,
+                      style: Theme.of(context).textTheme.titleMedium,
+                      textAlign:
+                          WidgetBuilderInherited.of(
+                            context,
+                          ).uiConfig.titleAlign,
                     ),
-            ),
-            // the controls float on top of the page content instead of
-            // stacking below it, so the page keeps the full height — which
-            // matters most when the software keyboard halves it
-            Expanded(
-              child: Stack(
-                children: [
-                  Positioned.fill(
-                    child: PageView.builder(
-                      controller: _pageController,
-                      physics: const NeverScrollableScrollPhysics(),
-                      scrollDirection: config.transitionAxis,
-                      itemCount: _pageCount,
-                      findChildIndexCallback: (key) {
-                        if (key is! ValueKey<String>) return null;
-                        if (key.value == _reviewPageId) return _steps.length;
-                        final index =
-                            _steps.indexWhere((step) => step.id == key.value);
-                        return index < 0 ? null : index;
-                      },
-                      itemBuilder: (context, index) {
-                        if (index >= _steps.length) {
-                          return _ReviewPage(
-                            key: const ValueKey<String>(_reviewPageId),
-                            steps: _steps,
-                            config: config,
-                            onEditStep: _animateToPage,
-                            bottomClearance: _controlsClearance,
-                          );
-                        }
-                        final step = _steps[index];
-                        return _KeepAlivePage(
-                          key: ValueKey<String>(step.id),
-                          // silence animations (e.g. looping ui:media) on
-                          // kept-alive off-screen pages
-                          child: TickerMode(
-                            enabled: index == _currentPage,
-                            child: _StepPage(
-                              step: step,
-                              formKey: _formKeyFor(step),
-                              mainSchema: widget.mainSchema,
-                              config: config,
-                              showDebugElements: widget.showDebugElements,
-                              onSchemaEvent: _onObjectSchemaEvent,
-                              bottomClearance: _controlsClearance,
-                            ),
+                  ),
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child:
+                      config.progressBuilder != null
+                          ? config.progressBuilder!(
+                            context,
+                            _currentPage + 1,
+                            totalPages,
+                          )
+                          : JsonFormStepProgress(
+                            currentStep: _currentPage + 1,
+                            totalSteps: totalPages,
+                            duration: config.transitionDuration,
+                            curve: config.transitionCurve,
                           ),
-                        );
-                      },
-                    ),
-                  ),
-                  Align(
-                    alignment: Alignment.bottomCenter,
-                    child: KeyedSubtree(
-                      key: _controlsKey,
-                      child: _StepControls(
-                        config: config,
-                        isFirstPage: _currentPage == 0,
-                        isLastPage: _currentPage >= _pageCount - 1,
-                        onBack: _goBack,
-                        onNext: _goNext,
-                        onSubmit: _trySubmit,
+                ),
+                // the controls float on top of the page content instead of
+                // stacking below it, so the page keeps the full height — which
+                // matters most when the software keyboard halves it
+                Expanded(
+                  child: Stack(
+                    children: [
+                      Positioned.fill(
+                        child: PageView.builder(
+                          controller: _pageController,
+                          physics: const NeverScrollableScrollPhysics(),
+                          scrollDirection: config.transitionAxis,
+                          itemCount: _pageCount,
+                          findChildIndexCallback: (key) {
+                            if (key is! ValueKey<String>) return null;
+                            if (key.value == _reviewPageId)
+                              return _steps.length;
+                            final index = _steps.indexWhere(
+                              (step) => step.id == key.value,
+                            );
+                            return index < 0 ? null : index;
+                          },
+                          itemBuilder: (context, index) {
+                            if (index >= _steps.length) {
+                              return _ReviewPage(
+                                key: const ValueKey<String>(_reviewPageId),
+                                steps: _steps,
+                                config: config,
+                                onEditStep: _animateToPage,
+                                bottomClearance: _controlsClearance,
+                              );
+                            }
+                            final step = _steps[index];
+                            return _KeepAlivePage(
+                              key: ValueKey<String>(step.id),
+                              // silence animations (e.g. looping ui:media) on
+                              // kept-alive off-screen pages
+                              child: TickerMode(
+                                enabled: index == _currentPage,
+                                child: _StepPage(
+                                  step: step,
+                                  formKey: _formKeyFor(step),
+                                  mainSchema: widget.mainSchema,
+                                  config: config,
+                                  showDebugElements: widget.showDebugElements,
+                                  onSchemaEvent: _onObjectSchemaEvent,
+                                  bottomClearance: _controlsClearance,
+                                ),
+                              ),
+                            );
+                          },
+                        ),
                       ),
-                    ),
+                      Align(
+                        alignment: Alignment.bottomCenter,
+                        child: KeyedSubtree(
+                          key: _controlsKey,
+                          child: _StepControls(
+                            config: config,
+                            isFirstPage: _currentPage == 0,
+                            isLastPage: _currentPage >= _pageCount - 1,
+                            onBack: _goBack,
+                            onNext: _goNext,
+                            onSubmit: _trySubmit,
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
-          ],
-        ),
-      );
-    });
+          ),
+        );
+      },
+    );
   }
+}
+
+/// Exposes the current stepped form's navigation hooks to descendant
+/// fields, so an enum selection or a keyboard action button deep in the
+/// tree can ask to move on.
+class SteppedFormScope extends InheritedWidget {
+  const SteppedFormScope({
+    super.key,
+    required this.requestAutoAdvance,
+    required this.onTextSubmitted,
+    required this.controlsClearance,
+    required super.child,
+  });
+
+  final VoidCallback requestAutoAdvance;
+
+  /// measured height of the floating controls; fields use it as bottom
+  /// [TextField.scrollPadding] so focus-driven auto-scroll clears them
+  final double controlsClearance;
+
+  /// keyboard action button (enter/done/next) pressed in a text field:
+  /// focus the step's next text field, or advance to the next page
+  final VoidCallback onTextSubmitted;
+
+  static SteppedFormScope? maybeOf(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<SteppedFormScope>();
+
+  @override
+  bool updateShouldNotify(SteppedFormScope oldWidget) =>
+      controlsClearance != oldWidget.controlsClearance;
 }
 
 /// One step of the form: media, header and the step's fields wrapped in
@@ -459,8 +549,10 @@ class _ReviewPage extends StatelessWidget {
                 title: Text(
                   schema.title != kNoTitle ? schema.title : schema.id,
                 ),
-                subtitle: Text(_formatValue(
-                    schema, jsonFormDataAtPath(data, schema.idKey))),
+                subtitle: _valueWidget(
+                  schema,
+                  jsonFormDataAtPath(data, schema.idKey),
+                ),
                 trailing: const Icon(Icons.edit_outlined, size: 20),
                 onTap: () => onEditStep(i),
               ),
@@ -469,10 +561,37 @@ class _ReviewPage extends StatelessWidget {
     );
   }
 
+  /// file answers are data-url strings (or lists of them) — never show
+  /// those; render one file icon per uploaded file instead
+  Widget _valueWidget(Schema schema, dynamic value) {
+    final isFileField =
+        schema is SchemaProperty && schema.format == PropertyFormat.dataurl;
+    if (isFileField) {
+      final count =
+          value == null || (value is List && value.isEmpty)
+              ? 0
+              : value is List
+              ? value.length
+              : 1;
+      if (count == 0) return const Text('—');
+      return Row(
+        children: [
+          for (var i = 0; i < count; i++)
+            const Padding(
+              padding: EdgeInsets.only(right: 4),
+              child: Icon(Icons.insert_drive_file_outlined, size: 18),
+            ),
+        ],
+      );
+    }
+    return Text(_formatValue(schema, value));
+  }
+
   String _formatValue(Schema schema, dynamic value) {
     if (value == null || (value is String && value.isEmpty)) {
       return '—';
     }
+    if (value is bool) return config.formatBoolean(value);
     // show the enum's display name, like the field itself does
     if (schema is SchemaProperty &&
         schema.enumm != null &&
@@ -522,22 +641,26 @@ class _StepControls extends StatelessWidget {
 
     Widget nextButton;
     if (isLastPage) {
-      nextButton = uiConfig.submitButtonBuilder != null
-          ? uiConfig.submitButtonBuilder!(onSubmit)
-          : ElevatedButton(
-              onPressed: onSubmit,
-              child: Text(config.submitButtonText),
-            );
+      nextButton =
+          uiConfig.submitButtonBuilder != null
+              ? uiConfig.submitButtonBuilder!(onSubmit)
+              : ElevatedButton(
+                onPressed: onSubmit,
+                child: Text(config.submitButtonText),
+              );
     } else {
-      nextButton = config.nextButtonBuilder != null
-          ? config.nextButtonBuilder!(onNext)
-          : ElevatedButton.icon(
-              onPressed: onNext,
-              icon: Icon(isVertical
-                  ? Icons.keyboard_arrow_down
-                  : Icons.keyboard_arrow_right),
-              label: Text(config.nextButtonText),
-            );
+      nextButton =
+          config.nextButtonBuilder != null
+              ? config.nextButtonBuilder!(onNext)
+              : ElevatedButton.icon(
+                onPressed: onNext,
+                icon: Icon(
+                  isVertical
+                      ? Icons.keyboard_arrow_down
+                      : Icons.keyboard_arrow_right,
+                ),
+                label: Text(config.nextButtonText),
+              );
     }
 
     return Row(
@@ -546,13 +669,23 @@ class _StepControls extends StatelessWidget {
         if (!isFirstPage)
           config.backButtonBuilder != null
               ? config.backButtonBuilder!(onBack)
-              : FilledButton.tonalIcon(
-                  onPressed: onBack,
-                  icon: Icon(isVertical
+              // deliberately quieter than the next/submit button, but with
+              // an opaque background so it stays legible over anything the
+              // page scrolls underneath it
+              : TextButton.icon(
+                onPressed: onBack,
+                style: TextButton.styleFrom(
+                  backgroundColor: Theme.of(context).colorScheme.surface,
+                  foregroundColor:
+                      Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+                icon: Icon(
+                  isVertical
                       ? Icons.keyboard_arrow_up
-                      : Icons.keyboard_arrow_left),
-                  label: Text(config.backButtonText),
-                )
+                      : Icons.keyboard_arrow_left,
+                ),
+                label: Text(config.backButtonText),
+              )
         else
           const SizedBox.shrink(),
         nextButton,

--- a/lib/src/builder/stepped_form_widgets.dart
+++ b/lib/src/builder/stepped_form_widgets.dart
@@ -99,6 +99,8 @@ class JsonFormStepHeader extends StatelessWidget {
               style: descriptionStyle ?? textTheme.bodyMedium,
             ),
           ),
+        // breathing room between the header and the step's fields
+        const SizedBox(height: 12),
       ],
     );
   }

--- a/lib/src/builder/widget_builder.dart
+++ b/lib/src/builder/widget_builder.dart
@@ -99,7 +99,7 @@ class JsonForm extends StatefulWidget {
   final JsonFormSteppedConfig steppedConfig;
 
   @override
-  _JsonFormState createState() => _JsonFormState();
+  State<StatefulWidget> createState() => _JsonFormState();
 }
 
 class _JsonFormState extends State<JsonForm> {
@@ -137,6 +137,7 @@ class _JsonFormState extends State<JsonForm> {
       onChanged: widget.onChanged,
       initialData: _formData,
       inputDecoration: widget.inputDecoration,
+      displayMode: widget.displayMode,
       child: Builder(builder: (context) {
         final widgetBuilderInherited = WidgetBuilderInherited.of(context);
 
@@ -228,12 +229,12 @@ class _JsonFormState extends State<JsonForm> {
 
 class FormFromSchemaBuilder extends StatelessWidget {
   const FormFromSchemaBuilder({
-    Key? key,
+    super.key,
     required this.mainSchema,
     required this.schema,
     this.showDebugElements = true,
     this.schemaObject,
-  }) : super(key: key);
+  });
   final Schema mainSchema;
   final Schema schema;
   final bool showDebugElements;

--- a/lib/src/builder/widget_builder.dart
+++ b/lib/src/builder/widget_builder.dart
@@ -99,7 +99,7 @@ class JsonForm extends StatefulWidget {
   final JsonFormSteppedConfig steppedConfig;
 
   @override
-  State<StatefulWidget> createState() => _JsonFormState();
+  State<JsonForm> createState() => _JsonFormState();
 }
 
 class _JsonFormState extends State<JsonForm> {

--- a/lib/src/fields/checkbox_form_field.dart
+++ b/lib/src/fields/checkbox_form_field.dart
@@ -4,25 +4,18 @@ import 'package:flutter_jsonschema_builder/src/builder/logic/widget_builder_logi
     show WidgetBuilderInherited;
 import 'package:flutter_jsonschema_builder/src/fields/fields.dart';
 import 'package:flutter_jsonschema_builder/src/fields/shared.dart';
-import '../models/models.dart';
 
 class CheckboxJFormField extends PropertyFieldWidget<bool> {
   const CheckboxJFormField({
-    Key? key,
-    required SchemaProperty property,
-    required final ValueSetter<bool?> onSaved,
-    ValueChanged<bool?>? onChanged,
-    final String? Function(dynamic)? customValidator,
-  }) : super(
-          key: key,
-          property: property,
-          onSaved: onSaved,
-          onChanged: onChanged,
-          customValidator: customValidator,
-        );
+    super.key,
+    required super.property,
+    required super.onSaved,
+    super.onChanged,
+    super.customValidator,
+  });
 
   @override
-  _CheckboxJFormFieldState createState() => _CheckboxJFormFieldState();
+  State<StatefulWidget> createState() => _CheckboxJFormFieldState();
 }
 
 class _CheckboxJFormFieldState extends State<CheckboxJFormField> {
@@ -37,7 +30,9 @@ class _CheckboxJFormFieldState extends State<CheckboxJFormField> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        FieldHeader(property: widget.property),
+        // the tile carries the title as its label — the header would
+        // otherwise show it a second time right above
+        FieldHeader(property: widget.property, showTitle: false),
         FormField<bool>(
           key: Key(widget.property.idKey),
           initialValue: widget.property.defaultValue ?? false,
@@ -63,24 +58,29 @@ class _CheckboxJFormFieldState extends State<CheckboxJFormField> {
               children: [
                 CheckboxListTile(
                   value: (field.value == null) ? false : field.value,
+                  dense: true,
+                  contentPadding: EdgeInsets.zero,
+                  visualDensity: VisualDensity.compact,
                   title: Text(
-                    widget.property.title,
-                    style: widget.property.readOnly
-                        ? Theme.of(context)
-                            .textTheme
-                            .titleMedium!
-                            .apply(color: Colors.grey)
-                        : Theme.of(context).textTheme.titleMedium,
+                    '${widget.property.title}'
+                    '${widget.property.required ? " *" : ""}',
+                    style:
+                        widget.property.readOnly
+                            ? Theme.of(
+                              context,
+                            ).textTheme.titleMedium!.apply(color: Colors.grey)
+                            : Theme.of(context).textTheme.titleMedium,
                   ),
                   controlAffinity: ListTileControlAffinity.leading,
-                  onChanged: widget.property.readOnly
-                      ? null
-                      : (bool? value) {
-                          field.didChange(value);
-                          if (widget.onChanged != null && value != null) {
-                            widget.onChanged!(value);
-                          }
-                        },
+                  onChanged:
+                      widget.property.readOnly
+                          ? null
+                          : (bool? value) {
+                            field.didChange(value);
+                            if (widget.onChanged != null && value != null) {
+                              widget.onChanged!(value);
+                            }
+                          },
                 ),
                 if (field.hasError) CustomErrorText(text: field.errorText!),
               ],

--- a/lib/src/fields/checkbox_form_field.dart
+++ b/lib/src/fields/checkbox_form_field.dart
@@ -15,7 +15,7 @@ class CheckboxJFormField extends PropertyFieldWidget<bool> {
   });
 
   @override
-  State<StatefulWidget> createState() => _CheckboxJFormFieldState();
+  State<CheckboxJFormField> createState() => _CheckboxJFormFieldState();
 }
 
 class _CheckboxJFormFieldState extends State<CheckboxJFormField> {

--- a/lib/src/fields/number_form_field.dart
+++ b/lib/src/fields/number_form_field.dart
@@ -18,11 +18,23 @@ class NumberJFormField extends PropertyFieldWidget<String?> {
   });
 
   @override
-  State<StatefulWidget> createState() => _NumberJFormFieldState();
+  State<NumberJFormField> createState() => _NumberJFormFieldState();
 }
 
 class _NumberJFormFieldState extends State<NumberJFormField> {
   Timer? _timer;
+
+  /// value typed since the last onChanged dispatch, so a keyboard-driven
+  /// step advance can flush it instead of losing it to the pending timer
+  String? _pendingValue;
+
+  /// dispatch a still-pending debounced value right now
+  void _flushDebounce() {
+    if (_timer?.isActive ?? false) _timer!.cancel();
+    final value = _pendingValue;
+    _pendingValue = null;
+    if (value != null && widget.onChanged != null) widget.onChanged!(value);
+  }
 
   @override
   void initState() {
@@ -50,18 +62,23 @@ class _NumberJFormFieldState extends State<NumberJFormField> {
           keyboardType: TextInputType.number,
           textInputAction: steppedScope != null ? TextInputAction.next : null,
           // focus-driven auto-scroll must clear the floating controls
-          scrollPadding:
-              steppedScope != null
-                  ? EdgeInsets.fromLTRB(
-                    20,
-                    20,
-                    20,
-                    steppedScope.controlsClearance + 20,
-                  )
-                  : const EdgeInsets.all(20),
+          scrollPadding: steppedScope != null
+              ? EdgeInsets.fromLTRB(
+                  20,
+                  20,
+                  20,
+                  steppedScope.controlsClearance + 20,
+                )
+              : const EdgeInsets.all(20),
           // onEditingComplete (not onFieldSubmitted) replaces the default
-          // focus handling, so the scope decides where focus goes
-          onEditingComplete: steppedScope?.onTextSubmitted,
+          // focus handling, so the scope decides where focus goes; the
+          // debounce is flushed first so dependency updates aren't lost
+          onEditingComplete: steppedScope == null
+              ? null
+              : () {
+                  _flushDebounce();
+                  steppedScope.onTextSubmitted();
+                },
           inputFormatters: <TextInputFormatter>[
             FilteringTextInputFormatter.allow(RegExp('[0-9.,]+')),
           ],
@@ -73,16 +90,17 @@ class _NumberJFormFieldState extends State<NumberJFormField> {
           onChanged: (value) {
             if (_timer != null && _timer!.isActive) _timer!.cancel();
 
+            _pendingValue = value;
             _timer = Timer(const Duration(seconds: 1), () {
+              _pendingValue = null;
               if (widget.onChanged != null) widget.onChanged!(value);
             });
           },
-          style:
-              widget.property.readOnly
-                  ? Theme.of(
-                    context,
-                  ).textTheme.titleMedium!.apply(color: Colors.grey)
-                  : Theme.of(context).textTheme.titleMedium,
+          style: widget.property.readOnly
+              ? Theme.of(
+                  context,
+                ).textTheme.titleMedium!.apply(color: Colors.grey)
+              : Theme.of(context).textTheme.titleMedium,
           validator: (String? value) {
             if (widget.property.required && value != null && value.isEmpty) {
               return uiConfig.requiredText ?? 'Required';
@@ -103,9 +121,9 @@ class _NumberJFormFieldState extends State<NumberJFormField> {
               InputDecoration(
                 helperText:
                     widget.property.help != null &&
-                            widget.property.help!.isNotEmpty
-                        ? widget.property.help
-                        : null,
+                        widget.property.help!.isNotEmpty
+                    ? widget.property.help
+                    : null,
                 errorStyle: Theme.of(context).textTheme.bodyMedium!.apply(
                   color: Theme.of(context).colorScheme.error,
                 ),

--- a/lib/src/fields/number_form_field.dart
+++ b/lib/src/fields/number_form_field.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_jsonschema_builder/src/builder/field_header_widget.dart';
 import 'package:flutter_jsonschema_builder/src/builder/logic/widget_builder_logic.dart';
+import 'package:flutter_jsonschema_builder/src/builder/stepped_form_builder.dart';
 import 'package:flutter_jsonschema_builder/src/fields/fields.dart';
 
 class NumberJFormField extends PropertyFieldWidget<String?> {
@@ -17,7 +18,7 @@ class NumberJFormField extends PropertyFieldWidget<String?> {
   });
 
   @override
-  _NumberJFormFieldState createState() => _NumberJFormFieldState();
+  State<StatefulWidget> createState() => _NumberJFormFieldState();
 }
 
 class _NumberJFormFieldState extends State<NumberJFormField> {
@@ -38,6 +39,8 @@ class _NumberJFormFieldState extends State<NumberJFormField> {
   @override
   Widget build(BuildContext context) {
     final uiConfig = WidgetBuilderInherited.of(context).uiConfig;
+    // in stepped mode the keyboard action button advances the form
+    final steppedScope = SteppedFormScope.maybeOf(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -45,8 +48,22 @@ class _NumberJFormFieldState extends State<NumberJFormField> {
         TextFormField(
           key: Key(widget.property.idKey),
           keyboardType: TextInputType.number,
+          textInputAction: steppedScope != null ? TextInputAction.next : null,
+          // focus-driven auto-scroll must clear the floating controls
+          scrollPadding:
+              steppedScope != null
+                  ? EdgeInsets.fromLTRB(
+                    20,
+                    20,
+                    20,
+                    steppedScope.controlsClearance + 20,
+                  )
+                  : const EdgeInsets.all(20),
+          // onEditingComplete (not onFieldSubmitted) replaces the default
+          // focus handling, so the scope decides where focus goes
+          onEditingComplete: steppedScope?.onTextSubmitted,
           inputFormatters: <TextInputFormatter>[
-            FilteringTextInputFormatter.allow(RegExp('[0-9.,]+'))
+            FilteringTextInputFormatter.allow(RegExp('[0-9.,]+')),
           ],
           autofocus: false,
           initialValue: widget.property.defaultValue,
@@ -60,12 +77,12 @@ class _NumberJFormFieldState extends State<NumberJFormField> {
               if (widget.onChanged != null) widget.onChanged!(value);
             });
           },
-          style: widget.property.readOnly
-              ? Theme.of(context)
-                  .textTheme
-                  .titleMedium!
-                  .apply(color: Colors.grey)
-              : Theme.of(context).textTheme.titleMedium,
+          style:
+              widget.property.readOnly
+                  ? Theme.of(
+                    context,
+                  ).textTheme.titleMedium!.apply(color: Colors.grey)
+                  : Theme.of(context).textTheme.titleMedium,
           validator: (String? value) {
             if (widget.property.required && value != null && value.isEmpty) {
               return uiConfig.requiredText ?? 'Required';
@@ -81,16 +98,17 @@ class _NumberJFormFieldState extends State<NumberJFormField> {
               return widget.customValidator!(value);
             return null;
           },
-          decoration: widget.decoration ??
+          decoration:
+              widget.decoration ??
               InputDecoration(
-                helperText: widget.property.help != null &&
-                        widget.property.help!.isNotEmpty
-                    ? widget.property.help
-                    : null,
-                errorStyle: Theme.of(context)
-                    .textTheme
-                    .bodyMedium!
-                    .apply(color: Theme.of(context).colorScheme.error),
+                helperText:
+                    widget.property.help != null &&
+                            widget.property.help!.isNotEmpty
+                        ? widget.property.help
+                        : null,
+                errorStyle: Theme.of(context).textTheme.bodyMedium!.apply(
+                  color: Theme.of(context).colorScheme.error,
+                ),
               ),
         ),
       ],

--- a/lib/src/fields/radio_button_form_field.dart
+++ b/lib/src/fields/radio_button_form_field.dart
@@ -17,7 +17,7 @@ class RadioButtonJFormField extends PropertyFieldWidget<dynamic> {
   });
 
   @override
-  State<StatefulWidget> createState() => _RadioButtonJFormFieldState();
+  State<RadioButtonJFormField> createState() => _RadioButtonJFormFieldState();
 }
 
 class _RadioButtonJFormFieldState extends State<RadioButtonJFormField> {

--- a/lib/src/fields/radio_button_form_field.dart
+++ b/lib/src/fields/radio_button_form_field.dart
@@ -17,7 +17,7 @@ class RadioButtonJFormField extends PropertyFieldWidget<dynamic> {
   });
 
   @override
-  _RadioButtonJFormFieldState createState() => _RadioButtonJFormFieldState();
+  State<StatefulWidget> createState() => _RadioButtonJFormFieldState();
 }
 
 class _RadioButtonJFormFieldState extends State<RadioButtonJFormField> {
@@ -87,23 +87,33 @@ class _RadioButtonJFormFieldState extends State<RadioButtonJFormField> {
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: List<Widget>.generate(
-                  widget.property.enumNames?.length ?? 0,
+                  widget.property.enumNames?.length ??
+                      widget.property.enumm?.length ??
+                      0,
                   (int i) => RadioListTile(
+                        dense: true,
+                        contentPadding: EdgeInsets.zero,
+                        visualDensity: VisualDensity.compact,
                         value: widget.property.enumm != null
                             ? widget.property.enumm![i]
                             : i,
-                        title: Text(widget.property.enumNames?[i],
+                        title: Text(
+                            widget.property.enumNames?[i] ??
+                                widget.property.enumm![i].toString(),
                             style: widget.property.readOnly
                                 ? Theme.of(context)
                                     .textTheme
                                     .titleMedium!
                                     .apply(color: Colors.grey)
                                 : Theme.of(context).textTheme.titleMedium),
+                        // RadioGroup (the replacement) requires Flutter
+                        // >=3.32; migrate when the floor moves past it
+                        // ignore: deprecated_member_use
                         groupValue: groupValue,
+                        // ignore: deprecated_member_use
                         onChanged: widget.property.readOnly
                             ? null
                             : (dynamic value) {
-                                print(value);
                                 groupValue = value;
                                 if (value != null) {
                                   field.didChange(groupValue);

--- a/lib/src/fields/text_form_field.dart
+++ b/lib/src/fields/text_form_field.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_jsonschema_builder/src/builder/field_header_widget.dart';
+import 'package:flutter_jsonschema_builder/src/builder/stepped_form_builder.dart';
 import 'package:flutter_jsonschema_builder/src/builder/logic/widget_builder_logic.dart';
 import 'package:flutter_jsonschema_builder/src/fields/fields.dart';
 import 'package:flutter_jsonschema_builder/src/utils/input_validation_json_schema.dart';
@@ -21,7 +22,7 @@ class TextJFormField extends PropertyFieldWidget<String> {
   });
 
   @override
-  _TextJFormFieldState createState() => _TextJFormFieldState();
+  State<StatefulWidget> createState() => _TextJFormFieldState();
 }
 
 class _TextJFormFieldState extends State<TextJFormField> {
@@ -42,6 +43,10 @@ class _TextJFormFieldState extends State<TextJFormField> {
   @override
   Widget build(BuildContext context) {
     final uiConfig = WidgetBuilderInherited.of(context).uiConfig;
+    // in stepped mode the keyboard action button advances the form;
+    // textareas keep the default action so enter inserts a newline
+    final isTextArea = widget.property.widget == "textarea";
+    final steppedScope = isTextArea ? null : SteppedFormScope.maybeOf(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -52,7 +57,21 @@ class _TextJFormFieldState extends State<TextJFormField> {
             key: Key(widget.property.idKey),
             autofocus: (widget.property.autoFocus ?? false),
             keyboardType: getTextInputTypeFromFormat(widget.property.format),
-            maxLines: widget.property.widget == "textarea" ? null : 1,
+            maxLines: isTextArea ? null : 1,
+            textInputAction: steppedScope != null ? TextInputAction.next : null,
+            // focus-driven auto-scroll must clear the floating controls
+            scrollPadding:
+                steppedScope != null
+                    ? EdgeInsets.fromLTRB(
+                      20,
+                      20,
+                      20,
+                      steppedScope.controlsClearance + 20,
+                    )
+                    : const EdgeInsets.all(20),
+            // onEditingComplete (not onFieldSubmitted) replaces the default
+            // focus handling, so the scope decides where focus goes
+            onEditingComplete: steppedScope?.onTextSubmitted,
             obscureText: widget.property.format == PropertyFormat.password,
             initialValue: widget.property.defaultValue ?? '',
             onSaved: widget.onSaved,
@@ -70,7 +89,9 @@ class _TextJFormFieldState extends State<TextJFormField> {
             validator: (String? value) {
               if (widget.property.required && value != null) {
                 final validated = inputValidationJsonSchema(
-                    newValue: value, property: widget.property);
+                  newValue: value,
+                  property: widget.property,
+                );
                 if (validated == 'Required') {
                   return uiConfig.requiredText ?? validated;
                 } else {
@@ -83,23 +104,24 @@ class _TextJFormFieldState extends State<TextJFormField> {
 
               return null;
             },
-            style: widget.property.readOnly
-                ? Theme.of(context)
-                    .textTheme
-                    .titleMedium!
-                    .apply(color: Colors.grey)
-                : Theme.of(context).textTheme.titleMedium,
-            decoration: widget.decoration ??
+            style:
+                widget.property.readOnly
+                    ? Theme.of(
+                      context,
+                    ).textTheme.titleMedium!.apply(color: Colors.grey)
+                    : Theme.of(context).textTheme.titleMedium,
+            decoration:
+                widget.decoration ??
                 InputDecoration(
-                  helperText: widget.property.help != null &&
-                          widget.property.help!.isNotEmpty
-                      ? widget.property.help
-                      : null,
+                  helperText:
+                      widget.property.help != null &&
+                              widget.property.help!.isNotEmpty
+                          ? widget.property.help
+                          : null,
                   labelStyle: const TextStyle(color: Colors.blue),
-                  errorStyle: Theme.of(context)
-                      .textTheme
-                      .bodyMedium!
-                      .apply(color: Theme.of(context).colorScheme.error),
+                  errorStyle: Theme.of(context).textTheme.bodyMedium!.apply(
+                    color: Theme.of(context).colorScheme.error,
+                  ),
                 ),
           ),
         ),
@@ -144,8 +166,9 @@ class _TextJFormFieldState extends State<TextJFormField> {
         textInputFormatter = EmailTextInputJsonFormatter();
         break;
       default:
-        textInputFormatter =
-            DefaultTextInputJsonFormatter(pattern: widget.property.pattern);
+        textInputFormatter = DefaultTextInputJsonFormatter(
+          pattern: widget.property.pattern,
+        );
         break;
     }
     return textInputFormatter;

--- a/lib/src/fields/text_form_field.dart
+++ b/lib/src/fields/text_form_field.dart
@@ -22,11 +22,23 @@ class TextJFormField extends PropertyFieldWidget<String> {
   });
 
   @override
-  State<StatefulWidget> createState() => _TextJFormFieldState();
+  State<TextJFormField> createState() => _TextJFormFieldState();
 }
 
 class _TextJFormFieldState extends State<TextJFormField> {
   Timer? _timer;
+
+  /// value typed since the last onChanged dispatch, so a keyboard-driven
+  /// step advance can flush it instead of losing it to the pending timer
+  String? _pendingValue;
+
+  /// dispatch a still-pending debounced value right now
+  void _flushDebounce() {
+    if (_timer?.isActive ?? false) _timer!.cancel();
+    final value = _pendingValue;
+    _pendingValue = null;
+    if (value != null && widget.onChanged != null) widget.onChanged!(value);
+  }
 
   @override
   void initState() {
@@ -60,18 +72,23 @@ class _TextJFormFieldState extends State<TextJFormField> {
             maxLines: isTextArea ? null : 1,
             textInputAction: steppedScope != null ? TextInputAction.next : null,
             // focus-driven auto-scroll must clear the floating controls
-            scrollPadding:
-                steppedScope != null
-                    ? EdgeInsets.fromLTRB(
-                      20,
-                      20,
-                      20,
-                      steppedScope.controlsClearance + 20,
-                    )
-                    : const EdgeInsets.all(20),
+            scrollPadding: steppedScope != null
+                ? EdgeInsets.fromLTRB(
+                    20,
+                    20,
+                    20,
+                    steppedScope.controlsClearance + 20,
+                  )
+                : const EdgeInsets.all(20),
             // onEditingComplete (not onFieldSubmitted) replaces the default
-            // focus handling, so the scope decides where focus goes
-            onEditingComplete: steppedScope?.onTextSubmitted,
+            // focus handling, so the scope decides where focus goes; the
+            // debounce is flushed first so dependency updates aren't lost
+            onEditingComplete: steppedScope == null
+                ? null
+                : () {
+                    _flushDebounce();
+                    steppedScope.onTextSubmitted();
+                  },
             obscureText: widget.property.format == PropertyFormat.password,
             initialValue: widget.property.defaultValue ?? '',
             onSaved: widget.onSaved,
@@ -82,7 +99,9 @@ class _TextJFormFieldState extends State<TextJFormField> {
             onChanged: (value) {
               if (_timer != null && _timer!.isActive) _timer!.cancel();
 
+              _pendingValue = value;
               _timer = Timer(const Duration(seconds: 1), () {
+                _pendingValue = null;
                 if (widget.onChanged != null) widget.onChanged!(value);
               });
             },
@@ -104,20 +123,19 @@ class _TextJFormFieldState extends State<TextJFormField> {
 
               return null;
             },
-            style:
-                widget.property.readOnly
-                    ? Theme.of(
-                      context,
-                    ).textTheme.titleMedium!.apply(color: Colors.grey)
-                    : Theme.of(context).textTheme.titleMedium,
+            style: widget.property.readOnly
+                ? Theme.of(
+                    context,
+                  ).textTheme.titleMedium!.apply(color: Colors.grey)
+                : Theme.of(context).textTheme.titleMedium,
             decoration:
                 widget.decoration ??
                 InputDecoration(
                   helperText:
                       widget.property.help != null &&
-                              widget.property.help!.isNotEmpty
-                          ? widget.property.help
-                          : null,
+                          widget.property.help!.isNotEmpty
+                      ? widget.property.help
+                      : null,
                   labelStyle: const TextStyle(color: Colors.blue),
                   errorStyle: Theme.of(context).textTheme.bodyMedium!.apply(
                     color: Theme.of(context).colorScheme.error,

--- a/lib/src/models/array_schema.dart
+++ b/lib/src/models/array_schema.dart
@@ -10,10 +10,10 @@ import '../models/models.dart';
 
 class SchemaArray extends Schema {
   SchemaArray({
-    required String id,
+    required super.id,
     required this.itemsBaseSchema,
     String? title,
-    String? description,
+    super.description,
     this.defaultValue,
     this.minItems,
     this.maxItems,
@@ -21,9 +21,7 @@ class SchemaArray extends Schema {
     this.items = const [],
     this.required = false,
   }) : super(
-          id: id,
           title: title ?? 'no-title',
-          description: description,
           type: SchemaType.array,
         );
 
@@ -68,7 +66,8 @@ class SchemaArray extends Schema {
     )
       ..parentIdKey = parentIdKey ?? this.parentIdKey
       ..dependentsAddedBy = dependentsAddedBy ?? this.dependentsAddedBy
-      ..uiMedia = uiMedia;
+      ..uiMedia = uiMedia
+      ..uiGroup = uiGroup;
 
     newSchema.items = items
         .map(
@@ -96,6 +95,9 @@ class SchemaArray extends Schema {
           if (data is Map) {
             uiMedia = JsonFormMedia.fromJson(Map<String, dynamic>.from(data));
           }
+          break;
+        case "ui:group":
+          uiGroup = data.toString();
           break;
         default:
           break;

--- a/lib/src/models/json_form_step.dart
+++ b/lib/src/models/json_form_step.dart
@@ -23,7 +23,9 @@ class JsonFormStep {
 
   final String? title;
   final String? description;
-  final JsonFormMedia? media;
+
+  /// mutable: a later `ui:group` member can contribute the group's media
+  JsonFormMedia? media;
 }
 
 /// Maps a plain JSON schema to a list of steps — no ui schema required:
@@ -32,10 +34,14 @@ class JsonFormStep {
 /// * a nested object becomes a single step holding all its fields, titled
 ///   by the object's own `title`/`description` (the same ones classic mode
 ///   renders as a section header)
-/// * `ui:media` on a field or object attaches media to its step
+/// * fields sharing a `ui:group` value share one step (at the position of
+///   the group's first field), keeping the data shape flat
+/// * `ui:media` on a field or object attaches media to its step; for a
+///   group, the first member carrying media wins
 List<JsonFormStep> extractJsonFormSteps(SchemaObject root) {
   final steps = <JsonFormStep>[];
   final usedIds = <String, int>{};
+  final groupSteps = <String, JsonFormStep>{};
 
   // dependency-added schemas can share an idKey (or lack one entirely);
   // suffix repeats so page keys and per-step form keys stay unique
@@ -59,12 +65,22 @@ List<JsonFormStep> extractJsonFormSteps(SchemaObject root) {
         media: child.uiMedia,
       ));
     } else {
-      steps.add(JsonFormStep(
-        id: uniqueId(child.idKey),
+      final group = child.uiGroup;
+      final existing = group != null ? groupSteps[group] : null;
+      if (existing != null) {
+        existing.schemas.add(child);
+        existing.media ??= child.uiMedia;
+        continue;
+      }
+
+      final step = JsonFormStep(
+        id: uniqueId(group != null ? 'group:$group' : child.idKey),
         parent: root,
         schemas: [child],
         media: child.uiMedia,
-      ));
+      );
+      if (group != null) groupSteps[group] = step;
+      steps.add(step);
     }
   }
 

--- a/lib/src/models/property_schema.dart
+++ b/lib/src/models/property_schema.dart
@@ -65,7 +65,9 @@ class SchemaProperty extends Schema {
       defaultValue: initialData?[id] ?? safeDefaultValue(json),
       description: json['description'],
       enumm: json['enum'],
-      enumNames: json['enumNames'],
+      // labels default to the stringified enum values when not given
+      enumNames: json['enumNames'] ??
+          (json['enum'] as List?)?.map((e) => e.toString()).toList(),
       minLength: json['minLength'],
       maxLength: json['maxLength'],
       pattern: json['pattern'],
@@ -121,7 +123,8 @@ class SchemaProperty extends Schema {
       ..required = required
       ..dependents = dependents
       ..isMultipleFile = isMultipleFile
-      ..uiMedia = uiMedia;
+      ..uiMedia = uiMedia
+      ..uiGroup = uiGroup;
 
     return newSchema;
   }
@@ -211,6 +214,9 @@ class SchemaProperty extends Schema {
           if (!isGeneralPass && data is Map) {
             uiMedia = JsonFormMedia.fromJson(Map<String, dynamic>.from(data));
           }
+          break;
+        case "ui:group":
+          if (!isGeneralPass) uiGroup = data.toString();
           break;
         case "ui:options":
           fileType = data["fileType"];

--- a/lib/src/models/schema.dart
+++ b/lib/src/models/schema.dart
@@ -81,6 +81,10 @@ class Schema {
   /// parsed from `ui:media`
   JsonFormMedia? uiMedia;
 
+  /// fields sharing the same `ui:group` value are placed on the same step
+  /// in the stepped display mode, without changing the data shape
+  String? uiGroup;
+
   // util props
   String? parentIdKey;
   List<String> dependentsAddedBy = [];
@@ -110,7 +114,9 @@ class Schema {
       description: description,
       parentIdKey: parentIdKey ?? this.parentIdKey,
       dependentsAddedBy: dependentsAddedBy ?? this.dependentsAddedBy,
-    )..uiMedia = uiMedia;
+    )
+      ..uiMedia = uiMedia
+      ..uiGroup = uiGroup;
   }
 }
 

--- a/lib/src/models/stepped_form_config.dart
+++ b/lib/src/models/stepped_form_config.dart
@@ -4,15 +4,21 @@ import 'json_form_media.dart';
 /// Builds a widget for a `ui:media` entry. Return `null` to fall back to the
 /// built-in rendering (`image`/`asset` types) or to render nothing for
 /// unknown types.
-typedef JsonFormMediaBuilder = Widget? Function(
-    BuildContext context, JsonFormMedia media);
+typedef JsonFormMediaBuilder =
+    Widget? Function(BuildContext context, JsonFormMedia media);
 
 /// Replaces the default progress indicator. [currentStep] is 1-based.
-typedef JsonFormStepProgressBuilder = Widget Function(
-    BuildContext context, int currentStep, int totalSteps);
+typedef JsonFormStepProgressBuilder =
+    Widget Function(BuildContext context, int currentStep, int totalSteps);
 
 /// Builds a navigation button that must invoke [onPressed] when tapped.
 typedef JsonFormStepButtonBuilder = Widget Function(VoidCallback onPressed);
+
+/// Formats a boolean answer for display (e.g. on the review step), the
+/// insertion point for i18n.
+typedef JsonFormBooleanFormatter = String Function(bool value);
+
+String _defaultFormatBoolean(bool value) => value ? 'Yes' : 'No';
 
 /// Configuration for [JsonFormDisplayMode.stepped], the one-question-at-a-time
 /// display mode of [JsonForm].
@@ -22,15 +28,17 @@ class JsonFormSteppedConfig {
     this.transitionDuration = const Duration(milliseconds: 350),
     this.transitionCurve = Curves.easeInOutCubic,
     this.showReviewStep = false,
+    this.autoAdvanceOnSelect = true,
     this.mediaBuilder,
     this.progressBuilder,
     this.nextButtonBuilder,
     this.backButtonBuilder,
     this.nextButtonText = 'Next',
-    this.backButtonText = 'Back',
+    this.backButtonText = 'Previous',
     this.submitButtonText = 'Submit',
     this.reviewTitle = 'Review your answers',
-    this.reviewDescription,
+    this.reviewDescription = 'Tap an answer to change it',
+    this.formatBoolean = _defaultFormatBoolean,
     this.stepTitleStyle,
     this.stepDescriptionStyle,
   });
@@ -47,6 +55,11 @@ class JsonFormSteppedConfig {
   /// tapping an answer jumps back to its step. When `false`, the last step
   /// submits directly.
   final bool showReviewStep;
+
+  /// when `true`, picking an enum value (radio or dropdown) advances to the
+  /// next step automatically — but only on steps with a single field, so
+  /// grouped steps still wait for the next button.
+  final bool autoAdvanceOnSelect;
 
   /// renders `ui:media` entries. Called for every media type before the
   /// built-in `image`/`asset` rendering, so it can both add support for
@@ -72,6 +85,9 @@ class JsonFormSteppedConfig {
   final String reviewTitle;
 
   final String? reviewDescription;
+
+  /// how boolean answers are displayed (review step); defaults to Yes/No
+  final JsonFormBooleanFormatter formatBoolean;
 
   /// style of step titles, defaults to [TextTheme.headlineSmall] of the
   /// ambient theme

--- a/test/stepped_form_test.dart
+++ b/test/stepped_form_test.dart
@@ -55,12 +55,8 @@ const dependencyJsonSchema = '''
 }
 ''';
 
-Future<void> selectDropdownValue(
-    WidgetTester tester, String key, String value) async {
-  // the step's page shares the property's key — target the dropdown itself
-  await tester.tap(find.byWidgetPredicate((widget) =>
-      widget is DropdownButtonFormField && widget.key == Key(key)));
-  await tester.pumpAndSettle();
+/// enums render as radio lists in stepped mode — select by tapping the label
+Future<void> selectRadioValue(WidgetTester tester, String value) async {
   await tester.tap(find.text(value).last);
   await tester.pumpAndSettle();
 }
@@ -122,6 +118,28 @@ void main() {
       expect(steps[1].media?.type, 'image');
       expect(steps[1].media?.src, 'https://example.com/age.png');
       expect(steps[2].media, isNull);
+    });
+
+    test(
+        'ui:group merges flat fields onto one step at the first member\'s '
+        'position, with the first media carried by a member', () {
+      const uiSchema = '''
+      {
+        "age": {"ui:group": "personal"},
+        "bio": {
+          "ui:group": "personal",
+          "ui:media": {"type": "image", "src": "https://example.com/p.png"}
+        }
+      }
+      ''';
+      final steps =
+          extractJsonFormSteps(parseSchema(testJsonSchema, uiSchema: uiSchema));
+
+      expect(steps.length, 2);
+      expect(steps[1].id, 'group:personal');
+      expect(steps[1].schemas.map((s) => s.id), ['age', 'bio']);
+      expect(steps[1].parent.id, kGenesisIdKey);
+      expect(steps[1].media?.src, 'https://example.com/p.png');
     });
 
     test('duplicate property ids still produce unique step ids', () {
@@ -205,7 +223,7 @@ void main() {
       expect(find.text('1 / 3'), findsOneWidget);
       expect(find.text('Next'), findsOneWidget);
       // no back button on the first step
-      expect(find.text('Back'), findsNothing);
+      expect(find.text('Previous'), findsNothing);
     });
 
     testWidgets('validation blocks advancing past a required field',
@@ -254,9 +272,9 @@ void main() {
       expect(find.text('2 / 3'), findsOneWidget);
       expect(find.textContaining('Age'), findsOneWidget);
       expect(find.byKey(const Key('custom-image-media')), findsOneWidget);
-      expect(find.text('Back'), findsOneWidget);
+      expect(find.text('Previous'), findsOneWidget);
 
-      await tester.tap(find.text('Back'));
+      await tester.tap(find.text('Previous'));
       await tester.pumpAndSettle();
 
       // the text entered on step 1 survived the round trip
@@ -302,6 +320,37 @@ void main() {
       // the number field stores its raw text value, as in fullForm mode
       expect(savedData['age'], '36');
       expect(savedData['bio'], 'First programmer');
+    });
+
+    testWidgets('review step renders file answers as icons, not data urls',
+        (tester) async {
+      const schema = '''
+      {
+        "type": "object",
+        "properties": {
+          "photo": {"type": "string", "format": "data-url", "title": "Photo"},
+          "bio": {"type": "string", "title": "Bio"}
+        }
+      }
+      ''';
+      await tester.pumpWidget(buildTestApp(JsonForm(
+        jsonSchema: schema,
+        displayMode: JsonFormDisplayMode.stepped,
+        steppedConfig: const JsonFormSteppedConfig(showReviewStep: true),
+        fileHandler: () => {'*': (_) async => null},
+        initialData: const {'photo': 'data:image/png;base64,AAAA'},
+        onFormDataSaved: (_) {},
+      )));
+      await tester.pump();
+
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
+
+      // review page: an icon for the file, never the raw data url
+      expect(find.byIcon(Icons.insert_drive_file_outlined), findsOneWidget);
+      expect(find.textContaining('base64'), findsNothing);
     });
 
     testWidgets('review step lists answers and jumps back on tap',
@@ -353,6 +402,10 @@ void main() {
       await tester.pumpWidget(buildTestApp(JsonForm(
         jsonSchema: dependencyJsonSchema,
         displayMode: JsonFormDisplayMode.stepped,
+        // auto-advance off: this test stays on the trigger step to watch
+        // the dependent step come and go
+        steppedConfig:
+            const JsonFormSteppedConfig(autoAdvanceOnSelect: false),
         onFormDataSaved: (data) => savedData = data,
       )));
       await tester.pump();
@@ -360,14 +413,14 @@ void main() {
       expect(find.text('1 / 2'), findsOneWidget);
 
       // selecting the trigger value inserts the dependent step...
-      await selectDropdownValue(tester, 'pet', 'cat');
+      await selectRadioValue(tester, 'cat');
       expect(find.text('1 / 3'), findsOneWidget);
 
       // ...and selecting the other value removes it again
-      await selectDropdownValue(tester, 'pet', 'none');
+      await selectRadioValue(tester, 'none');
       expect(find.text('1 / 2'), findsOneWidget);
 
-      await selectDropdownValue(tester, 'pet', 'cat');
+      await selectRadioValue(tester, 'cat');
       expect(find.text('1 / 3'), findsOneWidget);
 
       // the inserted step comes right after its trigger and is navigable
@@ -390,6 +443,68 @@ void main() {
       expect(savedData['pet'], 'cat');
       expect(savedData['petName'], 'Whiskers');
       expect(savedData['bio'], 'Cat person');
+    });
+
+    testWidgets(
+        'selecting an enum value auto-advances a single-field step '
+        'but not a grouped one', (tester) async {
+      const schema = '''
+      {
+        "type": "object",
+        "properties": {
+          "pet": {"type": "string", "title": "Pet?", "enum": ["none", "cat"]},
+          "color": {"type": "string", "title": "Color?", "enum": ["red", "blue"]},
+          "bio": {"type": "string", "title": "Bio"}
+        }
+      }
+      ''';
+      const uiSchema = '''
+      {
+        "color": {"ui:group": "extra"},
+        "bio": {"ui:group": "extra"}
+      }
+      ''';
+      await tester.pumpWidget(buildTestApp(JsonForm(
+        jsonSchema: schema,
+        uiSchema: uiSchema,
+        displayMode: JsonFormDisplayMode.stepped,
+        onFormDataSaved: (_) {},
+      )));
+      await tester.pump();
+
+      expect(find.text('1 / 2'), findsOneWidget);
+      await selectRadioValue(tester, 'cat');
+      // single-field step: the selection advanced the page
+      expect(find.text('2 / 2'), findsOneWidget);
+
+      // grouped step: selecting does not advance
+      await selectRadioValue(tester, 'blue');
+      expect(find.text('2 / 2'), findsOneWidget);
+    });
+
+    testWidgets(
+        'the keyboard action button moves to the next text field on the '
+        'page, then to the next page', (tester) async {
+      await tester.pumpWidget(buildTestApp(JsonForm(
+        jsonSchema: testJsonSchema,
+        displayMode: JsonFormDisplayMode.stepped,
+        onFormDataSaved: (_) {},
+      )));
+      await tester.pump();
+
+      // step 1 holds two text fields (first, last)
+      await tester.showKeyboard(find.byKey(const Key('name.first')));
+      await tester.enterText(find.byKey(const Key('name.first')), 'Ada');
+      await tester.testTextInput.receiveAction(TextInputAction.next);
+      await tester.pumpAndSettle();
+
+      expect(find.text('1 / 3'), findsOneWidget);
+      expect(focusedTextField(tester), isNotNull);
+
+      // enter on the page's last text field advances the page
+      await tester.testTextInput.receiveAction(TextInputAction.next);
+      await tester.pumpAndSettle();
+      expect(find.text('2 / 3'), findsOneWidget);
     });
 
     testWidgets('a double-tap on Next advances a single step', (tester) async {
@@ -546,7 +661,7 @@ void main() {
       await flushTextDebounce(tester);
       expect(focusedTextField(tester), isNotNull);
 
-      await tester.tap(find.text('Back'));
+      await tester.tap(find.text('Previous'));
       await tester.pumpAndSettle();
       expect(focusedTextField(tester), isNull);
     });

--- a/test/stepped_form_test.dart
+++ b/test/stepped_form_test.dart
@@ -485,9 +485,11 @@ void main() {
     testWidgets(
         'the keyboard action button moves to the next text field on the '
         'page, then to the next page', (tester) async {
+      dynamic changedData;
       await tester.pumpWidget(buildTestApp(JsonForm(
         jsonSchema: testJsonSchema,
         displayMode: JsonFormDisplayMode.stepped,
+        onChanged: (data) => changedData = data,
         onFormDataSaved: (_) {},
       )));
       await tester.pump();
@@ -495,11 +497,14 @@ void main() {
       // step 1 holds two text fields (first, last)
       await tester.showKeyboard(find.byKey(const Key('name.first')));
       await tester.enterText(find.byKey(const Key('name.first')), 'Ada');
+      // no flushTextDebounce on purpose: submitting must flush the pending
+      // debounce itself, so the typed value propagates immediately
       await tester.testTextInput.receiveAction(TextInputAction.next);
       await tester.pumpAndSettle();
 
       expect(find.text('1 / 3'), findsOneWidget);
       expect(focusedTextField(tester), isNotNull);
+      expect(changedData?['name']?['first'], 'Ada');
 
       // enter on the page's last text field advances the page
       await tester.testTextInput.receiveAction(TextInputAction.next);


### PR DESCRIPTION
Stacked on #11. Follow-up UX work for the stepped display mode.

## Interaction
- **Enums render as radio lists in stepped mode** (explicit `ui:widget` still wins; classic mode unchanged). Radios fall back to `enum` values when `enumNames` is absent, and dispatch the value event so `oneOf` dependencies now resolve from radios too (pre-existing bug).
- **Auto-advance**: selecting an enum value moves to the next step — only on single-field steps, so grouped steps keep their Next button. Opt out via `JsonFormSteppedConfig.autoAdvanceOnSelect`.
- **Keyboard navigation**: the keyboard action button (enter/next/done) focuses the step's next text field, or advances the page from the last one. Focus-driven auto-scroll clears the floating controls via `TextField.scrollPadding`. Textareas keep enter-as-newline.
- **`ui:group`**: a new ui-schema key that puts flat fields on the same step without changing the data shape:
  ```json
  "street": {"ui:group": "address"},
  "city":   {"ui:group": "address"}
  ```

## Presentation
- Form title above the progress bar (like classic mode, one size smaller since it is always visible)
- Vertical breathing room between field headers and inputs in stepped mode
- Review step renders file answers as file icons (one per file) — never raw data-url strings — and booleans via the new `formatBoolean` config (default Yes/No, i18n insertion point)
- Back button reads "Previous" and is a quiet text button so Next reads as the primary action
- Checkbox/radio tiles are compact and flush-left; the checkbox no longer shows its title twice

Tests cover the radio default, auto-advance vs grouped steps, ui:group extraction, keyboard flow, and the review-page file/data-url regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/doneservices/codesmith/flutter_jsonschema_builder/pr/13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786119143&installation_id=141069855&pr_number=13&repository=doneservices%2Fflutter_jsonschema_builder&return_to=https%3A%2F%2Fgithub.com%2Fdoneservices%2Fflutter_jsonschema_builder%2Fpull%2F13&signature=dabe3d50a5823aa6456cbc2da1801787dc4da900adae8bd73546169697e9411f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved stepped-form navigation with keyboard “next” focus traversal and optional auto-advance when selecting enum/radio values on single-field steps.
  * Added stepped-step grouping (by UI grouping metadata) to merge related fields into a single step and enhance review-step rendering (including file uploads and boolean display options).
* **Bug Fixes**
  * Refined spacing in step headers and field headers, including optional title rendering where appropriate (e.g., checkboxes).
  * Updated step control labeling (e.g., “Previous”) and review rendering so file answers show as icons rather than raw data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->