### PR TITLE
Rework the example into a field showcase

### DIFF
--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -141,10 +141,12 @@ class DemoHomePage extends StatefulWidget {
 /// Default file handler for every `data-url` field: opens the platform file
 /// picker and encodes the result as a data URL, matching the schema format.
 Future<List<SchemaFormFile>?> _pickFiles(SchemaProperty property) async {
-  final result = await FilePicker.pickFiles(withData: true);
-  final file = result?.files.firstOrNull;
-  final bytes = file?.bytes;
-  if (file == null || bytes == null) return null;
+  final result = await FilePicker.pickFiles(
+    withData: true,
+    allowMultiple: property.isMultipleFile,
+  );
+  final files = result?.files ?? [];
+  if (files.isEmpty) return null;
   const mimeTypes = {
     'jpg': 'image/jpeg',
     'jpeg': 'image/jpeg',
@@ -152,19 +154,22 @@ Future<List<SchemaFormFile>?> _pickFiles(SchemaProperty property) async {
     'heic': 'image/heic',
     'pdf': 'application/pdf',
   };
-  return [
-    SchemaFormFile(
-      name: file.name,
-      value:
-          Uri.dataFromBytes(
-            bytes,
-            mimeType:
-                mimeTypes[file.extension?.toLowerCase()] ??
-                'application/octet-stream',
-          ).toString(),
-      bytes: bytes,
-    ),
-  ];
+  return files
+      .where((f) => f.bytes != null)
+      .map(
+        (f) => SchemaFormFile(
+          name: f.name,
+          value:
+              Uri.dataFromBytes(
+                f.bytes!,
+                mimeType:
+                    mimeTypes[f.extension?.toLowerCase()] ??
+                    'application/octet-stream',
+              ).toString(),
+          bytes: f.bytes!,
+        ),
+      )
+      .toList();
 }
 
 class _DemoHomePageState extends State<DemoHomePage> {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -147,10 +147,15 @@ Future<List<SchemaFormFile>?> _pickFiles(SchemaProperty property) async {
   );
   final files = result?.files ?? [];
   if (files.isEmpty) return null;
+  // ponytail: covers the formats this demo realistically picks; use
+  // package:mime if an app needs full coverage
   const mimeTypes = {
     'jpg': 'image/jpeg',
     'jpeg': 'image/jpeg',
     'png': 'image/png',
+    'gif': 'image/gif',
+    'webp': 'image/webp',
+    'bmp': 'image/bmp',
     'heic': 'image/heic',
     'pdf': 'application/pdf',
   };

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -97,8 +97,8 @@ const demoJsonSchema = '''
 ''';
 
 /// Ui schema showing the main keys: ui:media (bundled assets and a custom
-/// lottie type), ui:group for same-step grouping without changing the data
-/// shape, and ui:order.
+/// lottie type; rendered by the stepped mode only), ui:group for same-step
+/// grouping without changing the data shape, and ui:order.
 const demoUiSchema = '''
 {
   "ui:order": [

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_jsonschema_builder/flutter_jsonschema_builder.dart';
 import 'package:lottie/lottie.dart';
@@ -24,58 +25,109 @@ class MyApp extends StatelessWidget {
   }
 }
 
-/// A plain JSON schema that works in both display modes: the nested `name`
-/// object renders as a titled section in classic mode and becomes a single
-/// step (with the same title and description) in stepped mode.
+/// Demo schema covering the main field types and features: nested objects,
+/// enums, booleans, dates, files (single + multi) and dependencies.
 const demoJsonSchema = '''
 {
-  "title": "Tell us about you",
+  "title": "Field showcase",
+  "description": "The main field types and features, one of each.",
   "type": "object",
-  "required": ["email", "topic"],
   "properties": {
     "name": {
       "type": "object",
-      "title": "What should we call you?",
-      "description": "First things first — introduce yourself.",
-      "required": ["first"],
+      "title": "About you",
+      "description": "A nested object: a titled section in classic mode, a single step in stepped mode.",
+      "required": ["firstName"],
       "properties": {
-        "first": {"type": "string", "title": "First name"},
-        "last": {"type": "string", "title": "Last name"}
+        "firstName": {"type": "string", "title": "First name", "minLength": 2},
+        "lastName": {"type": "string", "title": "Last name"}
       }
     },
-    "email": {"type": "string", "title": "Email", "format": "email", "minLength": 5},
-    "topic": {
+    "email": {"type": "string", "format": "email", "title": "Email"},
+    "birthDate": {"type": "string", "format": "date", "title": "Birth date"},
+    "age": {"type": "integer", "title": "Age", "minimum": 0},
+    "favoriteColor": {
       "type": "string",
-      "title": "What brings you here?",
-      "enum": ["work", "hobby", "school"],
-      "enumNames": ["Work", "Hobby", "School"]
+      "title": "Favorite color",
+      "description": "Enum + enumNames: radio in stepped mode, dropdown in classic",
+      "enum": ["red", "green", "blue"],
+      "enumNames": ["Red", "Green", "Blue"]
     },
-    "excitement": {
-      "type": "integer",
-      "title": "How excited are you?",
-      "description": "1 = meh, 5 = can't wait",
-      "enum": [1, 2, 3, 4, 5],
-      "enumNames": ["1", "2", "3", "4", "5"]
+    "newsletter": {
+      "type": "boolean",
+      "title": "Subscribe to the newsletter",
+      "description": "A boolean: rendered as a checkbox"
     },
-    "comments": {"type": "string", "title": "Anything else?"}
+    "pet": {
+      "type": "string",
+      "title": "Do you have a pet?",
+      "description": "Selecting cat inserts a follow-up question (dependencies)",
+      "enum": ["none", "cat"]
+    },
+    "street": {"type": "string", "title": "Street"},
+    "city": {"type": "string", "title": "City"},
+    "avatar": {
+      "type": "string",
+      "format": "data-url",
+      "title": "Avatar",
+      "description": "Single file with image preview"
+    },
+    "attachments": {
+      "type": "array",
+      "title": "Attachments",
+      "description": "Multiple files via an array of data-urls",
+      "items": {"type": "string", "format": "data-url"}
+    }
+  },
+  "required": ["email", "favoriteColor", "newsletter", "avatar"],
+  "dependencies": {
+    "pet": {
+      "oneOf": [
+        {"properties": {"pet": {"enum": ["none"]}}},
+        {
+          "properties": {
+            "pet": {"enum": ["cat"]},
+            "petName": {"type": "string", "title": "Pet name"}
+          }
+        }
+      ]
+    }
   }
 }
 ''';
 
-/// The only step-specific ui schema addition is `ui:media`, which attaches
-/// an image or animation to a field's or object's step.
+/// Ui schema showing the main keys: ui:media (bundled assets and a custom
+/// lottie type), ui:group for same-step grouping without changing the data
+/// shape, and ui:order.
 const demoUiSchema = '''
 {
+  "ui:order": [
+    "name",
+    "email",
+    "birthDate",
+    "age",
+    "favoriteColor",
+    "newsletter",
+    "pet",
+    "street",
+    "city",
+    "avatar",
+    "attachments"
+  ],
   "name": {
-    "ui:media": {"type": "lottie", "src": "assets/pulse.json", "height": 160}
+    "ui:media": {"type": "asset", "src": "assets/gradient.png", "height": 120}
   },
-  "email": {
-    "ui:media": {"type": "asset", "src": "assets/gradient.png", "height": 150, "fit": "cover"}
-  },
-  "topic": {"ui:widget": "radio"},
-  "excitement": {
+  "favoriteColor": {
     "ui:media": {"type": "lottie", "src": "assets/pulse.json", "height": 120}
-  }
+  },
+  "avatar": {
+    "ui:options": {"filePreview": true, "fileType": "image"}
+  },
+  "attachments": {
+    "ui:options": {"filePreview": true, "fileType": "image"}
+  },
+  "street": {"ui:group": "address"},
+  "city": {"ui:group": "address"}
 }
 ''';
 
@@ -84,6 +136,35 @@ class DemoHomePage extends StatefulWidget {
 
   @override
   State<DemoHomePage> createState() => _DemoHomePageState();
+}
+
+/// Default file handler for every `data-url` field: opens the platform file
+/// picker and encodes the result as a data URL, matching the schema format.
+Future<List<SchemaFormFile>?> _pickFiles(SchemaProperty property) async {
+  final result = await FilePicker.pickFiles(withData: true);
+  final file = result?.files.firstOrNull;
+  final bytes = file?.bytes;
+  if (file == null || bytes == null) return null;
+  const mimeTypes = {
+    'jpg': 'image/jpeg',
+    'jpeg': 'image/jpeg',
+    'png': 'image/png',
+    'heic': 'image/heic',
+    'pdf': 'application/pdf',
+  };
+  return [
+    SchemaFormFile(
+      name: file.name,
+      value:
+          Uri.dataFromBytes(
+            bytes,
+            mimeType:
+                mimeTypes[file.extension?.toLowerCase()] ??
+                'application/octet-stream',
+          ).toString(),
+      bytes: bytes,
+    ),
+  ];
 }
 
 class _DemoHomePageState extends State<DemoHomePage> {
@@ -101,45 +182,51 @@ class _DemoHomePageState extends State<DemoHomePage> {
         actions: [
           PopupMenuButton<String>(
             icon: const Icon(Icons.tune),
-            onSelected: (value) => setState(() {
-              switch (value) {
-                case 'mode':
-                  _displayMode = isStepped
-                      ? JsonFormDisplayMode.fullForm
-                      : JsonFormDisplayMode.stepped;
-                  break;
-                case 'axis':
-                  _transitionAxis = _transitionAxis == Axis.vertical
-                      ? Axis.horizontal
-                      : Axis.vertical;
-                  break;
-                case 'review':
-                  _showReviewStep = !_showReviewStep;
-                  break;
-              }
-            }),
-            itemBuilder: (context) => [
-              PopupMenuItem(
-                value: 'mode',
-                child: Text(
-                  isStepped ? 'Switch to classic' : 'Switch to step by step',
-                ),
-              ),
-              if (isStepped) ...[
-                PopupMenuItem(
-                  value: 'axis',
-                  child: Text(
-                    'Transition: ${_transitionAxis == Axis.vertical ? 'vertical' : 'horizontal'}',
+            onSelected:
+                (value) => setState(() {
+                  switch (value) {
+                    case 'mode':
+                      _displayMode =
+                          isStepped
+                              ? JsonFormDisplayMode.fullForm
+                              : JsonFormDisplayMode.stepped;
+                      break;
+                    case 'axis':
+                      _transitionAxis =
+                          _transitionAxis == Axis.vertical
+                              ? Axis.horizontal
+                              : Axis.vertical;
+                      break;
+                    case 'review':
+                      _showReviewStep = !_showReviewStep;
+                      break;
+                  }
+                }),
+            itemBuilder:
+                (context) => [
+                  PopupMenuItem(
+                    value: 'mode',
+                    child: Text(
+                      isStepped
+                          ? 'Switch to classic'
+                          : 'Switch to step by step',
+                    ),
                   ),
-                ),
-                PopupMenuItem(
-                  value: 'review',
-                  child: Text(
-                    'Review step: ${_showReviewStep ? 'on' : 'off'}',
-                  ),
-                ),
-              ],
-            ],
+                  if (isStepped) ...[
+                    PopupMenuItem(
+                      value: 'axis',
+                      child: Text(
+                        'Transition: ${_transitionAxis == Axis.vertical ? 'vertical' : 'horizontal'}',
+                      ),
+                    ),
+                    PopupMenuItem(
+                      value: 'review',
+                      child: Text(
+                        'Review step: ${_showReviewStep ? 'on' : 'off'}',
+                      ),
+                    ),
+                  ],
+                ],
           ),
         ],
       ),
@@ -154,14 +241,12 @@ class _DemoHomePageState extends State<DemoHomePage> {
       jsonSchema: demoJsonSchema,
       uiSchema: demoUiSchema,
       showDebugElements: false,
+      fileHandler: () => {'*': _pickFiles},
       displayMode: JsonFormDisplayMode.stepped,
       steppedConfig: JsonFormSteppedConfig(
         transitionAxis: _transitionAxis,
         showReviewStep: _showReviewStep,
         reviewDescription: 'Tap an answer to change it.',
-        // The package has no Lottie dependency: the app decides how custom
-        // media types render. Returning null falls back to the built-in
-        // handling of the `image`/`asset` types.
         mediaBuilder: (context, media) {
           if (media.type == 'lottie') {
             return Lottie.asset(media.src, height: media.height ?? 160);
@@ -179,6 +264,7 @@ class _DemoHomePageState extends State<DemoHomePage> {
         jsonSchema: demoJsonSchema,
         uiSchema: demoUiSchema,
         showDebugElements: false,
+        fileHandler: () => {'*': _pickFiles},
         onFormDataSaved: _showResult,
       ),
     );
@@ -187,18 +273,19 @@ class _DemoHomePageState extends State<DemoHomePage> {
   void _showResult(dynamic data) {
     showDialog<void>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Form data'),
-        content: SingleChildScrollView(
-          child: Text(const JsonEncoder.withIndent('  ').convert(data)),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Close'),
+      builder:
+          (context) => AlertDialog(
+            title: const Text('Form data'),
+            content: SingleChildScrollView(
+              child: Text(const JsonEncoder.withIndent('  ').convert(data)),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Close'),
+              ),
+            ],
           ),
-        ],
-      ),
     );
   }
 }

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import file_picker
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.9"
+  args:
+    dependency: transitive
+    description:
+      name: args
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
@@ -65,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.14"
   extended_masked_text:
     dependency: transitive
     description:
@@ -89,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: f13a03000d942e476bc1ff0a736d2e9de711d2f89a95cd4c1d88f861c3348387
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -109,8 +133,21 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.35"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -210,6 +247,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   posix:
     dependency: transitive
     description:
@@ -303,6 +356,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
 sdks:
   dart: ">=3.12.0 <4.0.0"
   flutter: ">=3.44.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   # Only the example depends on lottie; the package itself renders custom
   # media types through JsonFormSteppedConfig.mediaBuilder.
   lottie: ^3.3.1
+  file_picker: ^11.0.2
 
 dev_dependencies:
   flutter_test:

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -9,7 +9,7 @@ void main() {
     await tester.pump();
 
     // first step of the stepped demo form
-    expect(find.text('What should we call you?'), findsOneWidget);
+    expect(find.text('About you'), findsOneWidget);
     expect(find.textContaining('First name'), findsOneWidget);
     expect(find.text('Next'), findsOneWidget);
 


### PR DESCRIPTION
Stacked on #14. Replaces the production-form copy in the example with a compact demo that exercises the main field types and features once each:

- Nested object (titled section/step, asset `ui:media`, `minLength`, nested required)
- Email format, date picker, number
- Enum + `enumNames` with lottie `ui:media` (radio in stepped, dropdown in classic)
- Boolean checkbox
- `dependencies`/`oneOf` follow-up question (pet → pet name)
- `ui:group` (street + city on one step, flat data)
- Single file with preview + network-image `ui:media`, and a multi-file array

Also adds `file_picker` to the example and refreshes generated platform files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/doneservices/codesmith/flutter_jsonschema_builder/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786119166&installation_id=141069855&pr_number=15&repository=doneservices%2Fflutter_jsonschema_builder&return_to=https%3A%2F%2Fgithub.com%2Fdoneservices%2Fflutter_jsonschema_builder%2Fpull%2F15&signature=5d5db281a63768fb8ec0260156658eea08ce8fb12c1dc074c3aff4370d3dd579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The demo now supports selecting files from your device for `data-url` form fields (single and multiple), with generated previews.
  * The sample form content has been refreshed to showcase additional field types, media options, and conditional sections.
* **Bug Fixes**
  * Improved the example app’s Android configuration for newer Flutter/Gradle behavior.
  * Updated the widget test to match the revised stepped form flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->