### PR TITLE
Document ui:group for grouping flat fields in stepped mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,27 @@ produces two steps — "What should we call you?" with both name fields, then
 email — and the submitted data mirrors the schema:
 `{"name": {"first": ..., "last": ...}, "email": ...}`.
 
+#### Grouping flat fields onto one step
+
+Wrapping fields in a nested object also nests the submitted data. When you want
+several top-level fields on the same step but a **flat** data shape, give them a
+shared `ui:group` value in the ui schema:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "first": {"type": "string", "title": "First name", "ui:group": "name"},
+    "last": {"type": "string", "title": "Last name", "ui:group": "name"},
+    "email": {"type": "string", "title": "Email", "format": "email"}
+  }
+}
+```
+
+`first` and `last` share one step (placed where the first group member appears),
+while the data stays flat: `{"first": ..., "last": ..., "email": ...}`. The
+group's step takes its `ui:media` from the first member that declares one.
+
 #### Step media: images and Lottie animations
 
 Each step can show an image or an animation above its fields, declared in the


### PR DESCRIPTION
Adds a "Grouping flat fields onto one step" subsection to the stepped-mode docs, covering `ui:group` — putting several top-level fields on one step while keeping the submitted data flat (the alternative to nesting them in an object).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/doneservices/codesmith/flutter_jsonschema_builder/pr/16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786171963&installation_id=141069855&pr_number=16&repository=doneservices%2Fflutter_jsonschema_builder&return_to=https%3A%2F%2Fgithub.com%2Fdoneservices%2Fflutter_jsonschema_builder%2Fpull%2F16&signature=d7a58175ff3889dde843482c4b435e08b99dda9f33072e6b00b71bbbf75d0bcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for grouping flat fields onto a single step in stepped display mode.
  * Included an example showing how related fields can share a step while keeping submitted data flat.
  * Clarified how grouped steps are ordered and how media settings are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->