### PR TITLE
Add unit tests for text input formatters

### DIFF
--- a/test/date_text_input_json_formatter_test.dart
+++ b/test/date_text_input_json_formatter_test.dart
@@ -70,8 +70,10 @@ void main() {
     });
 
     test('rejects an invalid day once the month digit is typed', () {
-      // Day "35" only fails validation at length 4, when the full day and the
-      // month tens digit are present.
+      // Typing "35" yields "35-" (the separator is appended eagerly, so the
+      // reformatted length is 3 and the length-2 day check never runs). The
+      // day is only re-validated at length 4, once the month tens digit is
+      // present — that is where "35" is finally rejected.
       final result =
           formatter.formatEditUpdate(_value('35-'), _value('35-0'));
       expect(result.text, '35-');

--- a/test/date_text_input_json_formatter_test.dart
+++ b/test/date_text_input_json_formatter_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_jsonschema_builder/src/utils/date_text_input_json_formatter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Builds a [TextEditingValue] with the caret collapsed at the end of [text].
+TextEditingValue _value(String text) => TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+
+void main() {
+  late DateTextInputJsonFormatter formatter;
+
+  setUp(() {
+    formatter = DateTextInputJsonFormatter();
+  });
+
+  group('DateTextInputJsonFormatter valid input', () {
+    test('accepts a valid first day digit', () {
+      final result = formatter.formatEditUpdate(_value(''), _value('1'));
+      expect(result.text, '1');
+    });
+
+    test('appends the separator eagerly after the second digit', () {
+      final result = formatter.formatEditUpdate(_value('1'), _value('12'));
+      expect(result.text, '12-');
+    });
+
+    test('accepts the month tens digit', () {
+      final result = formatter.formatEditUpdate(_value('12'), _value('120'));
+      expect(result.text, '12-0');
+    });
+
+    test('places the caret at the end of the reformatted text', () {
+      final result = formatter.formatEditUpdate(_value('12'), _value('120'));
+      expect(result.selection.baseOffset, result.text.length);
+    });
+
+    test('appends the second separator after the fourth digit', () {
+      final result =
+          formatter.formatEditUpdate(_value('12-0'), _value('12-01'));
+      expect(result.text, '12-01-');
+    });
+
+    test('accepts input that already contains separators', () {
+      final result =
+          formatter.formatEditUpdate(_value('12-'), _value('12-0'));
+      expect(result.text, '12-0');
+    });
+
+    test('accepts a fully typed valid date', () {
+      final result = formatter.formatEditUpdate(
+        _value('31-12-202'),
+        _value('31-12-2024'),
+      );
+      expect(result.text, '31-12-2024');
+    });
+  });
+
+  group('DateTextInputJsonFormatter rejected input', () {
+    test('rejects an out of range first day digit', () {
+      final result = formatter.formatEditUpdate(_value(''), _value('5'));
+      expect(result.text, '');
+    });
+
+    test('rejects an invalid month tens digit', () {
+      // A third digit outside [0-1] cannot start a valid month.
+      final result = formatter.formatEditUpdate(_value('12'), _value('123'));
+      expect(result.text, '12');
+    });
+
+    test('rejects an invalid day once the month digit is typed', () {
+      // Day "35" only fails validation at length 4, when the full day and the
+      // month tens digit are present.
+      final result =
+          formatter.formatEditUpdate(_value('35-'), _value('35-0'));
+      expect(result.text, '35-');
+    });
+
+    test('rejects input longer than 10 characters', () {
+      final result = formatter.formatEditUpdate(
+        _value('31-12-2024'),
+        _value('31-12-20245'),
+      );
+      expect(result.text, '31-12-2024');
+    });
+  });
+
+  group('DateTextInputJsonFormatter deletions', () {
+    test('deleting a trailing character passes through unchanged', () {
+      final result =
+          formatter.formatEditUpdate(_value('12-3'), _value('12-'));
+      expect(result.text, '12-');
+    });
+
+    test('clearing the field passes through', () {
+      final result =
+          formatter.formatEditUpdate(_value('12-01'), _value(''));
+      expect(result.text, '');
+    });
+
+    test('an equal-length replacement passes through unchanged', () {
+      // oldValue.text.length >= newValue.text.length returns newValue as-is,
+      // bypassing reformatting and validation.
+      final result = formatter.formatEditUpdate(_value('12'), _value('99'));
+      expect(result.text, '99');
+    });
+  });
+}

--- a/test/default_text_input_json_formatter_test.dart
+++ b/test/default_text_input_json_formatter_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_jsonschema_builder/src/utils/default_text_input_json_formatter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Builds a [TextEditingValue] with the caret collapsed at the end of [text].
+TextEditingValue _value(String text) => TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+
+void main() {
+  group('DefaultTextInputJsonFormatter without a pattern', () {
+    late DefaultTextInputJsonFormatter formatter;
+
+    setUp(() {
+      formatter = DefaultTextInputJsonFormatter();
+    });
+
+    test('accepts appending a regular character', () {
+      final result = formatter.formatEditUpdate(_value('ab'), _value('abc'));
+      expect(result.text, 'abc');
+    });
+
+    test('places the caret at the end of the text', () {
+      final result = formatter.formatEditUpdate(_value('ab'), _value('abc'));
+      expect(result.selection.baseOffset, result.text.length);
+    });
+
+    test('rejects a lone newline character', () {
+      // RegExp(r'.') does not match a line terminator.
+      final result = formatter.formatEditUpdate(_value(''), _value('\n'));
+      expect(result.text, '');
+    });
+
+    test('deletions pass through unchanged', () {
+      final result = formatter.formatEditUpdate(_value('abc'), _value('ab'));
+      expect(result.text, 'ab');
+    });
+
+    test('an equal-length replacement passes through unchanged', () {
+      final result = formatter.formatEditUpdate(_value('ab'), _value('xy'));
+      expect(result.text, 'xy');
+    });
+  });
+
+  group('DefaultTextInputJsonFormatter with a pattern', () {
+    test('accepts input matching the pattern', () {
+      final formatter = DefaultTextInputJsonFormatter(pattern: r'^[a-z]+$');
+      final result = formatter.formatEditUpdate(_value('ab'), _value('abc'));
+      expect(result.text, 'abc');
+    });
+
+    test('rejects input that does not match the pattern', () {
+      final formatter = DefaultTextInputJsonFormatter(pattern: r'^[a-z]+$');
+      final result = formatter.formatEditUpdate(_value('ab'), _value('ab1'));
+      expect(result.text, 'ab');
+    });
+
+    test('uses a partial (contains) match, not a full match', () {
+      // The pattern only needs to match somewhere in the text.
+      final formatter = DefaultTextInputJsonFormatter(pattern: r'[0-9]');
+      final result = formatter.formatEditUpdate(_value('a'), _value('a1'));
+      expect(result.text, 'a1');
+    });
+
+    test('deletions bypass the pattern check', () {
+      final formatter = DefaultTextInputJsonFormatter(pattern: r'^[a-z]+$');
+      // "ab1" would not match the pattern, but shrinking text is always kept.
+      final result = formatter.formatEditUpdate(_value('ab12'), _value('ab1'));
+      expect(result.text, 'ab1');
+    });
+  });
+}

--- a/test/email_text_input_json_formatter_test.dart
+++ b/test/email_text_input_json_formatter_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_jsonschema_builder/src/utils/email_text_input_json_formatter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Builds a [TextEditingValue] with the caret collapsed at the end of [text].
+TextEditingValue _value(String text) => TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+
+void main() {
+  late EmailTextInputJsonFormatter formatter;
+
+  setUp(() {
+    formatter = EmailTextInputJsonFormatter();
+  });
+
+  group('EmailTextInputJsonFormatter valid input', () {
+    test('accepts appending a regular character', () {
+      final result = formatter.formatEditUpdate(_value('a'), _value('ab'));
+      expect(result.text, 'ab');
+    });
+
+    test('accepts building a full valid email character by character', () {
+      const email = 'john.doe@example.com';
+      var current = '';
+      for (var i = 0; i < email.length; i++) {
+        final next = email.substring(0, i + 1);
+        final result =
+            formatter.formatEditUpdate(_value(current), _value(next));
+        expect(result.text, next,
+            reason: 'expected "$next" to be accepted while typing');
+        current = result.text;
+      }
+    });
+
+    test('accepts a single @', () {
+      final result =
+          formatter.formatEditUpdate(_value('john'), _value('john@'));
+      expect(result.text, 'john@');
+    });
+
+    test('accepts a special atom character when it is not the first char', () {
+      final result = formatter.formatEditUpdate(_value('a'), _value('a!'));
+      expect(result.text, 'a!');
+    });
+
+    test('accepts text just under the 255 character limit', () {
+      final old = 'a' * 253;
+      final next = 'a' * 254;
+      final result = formatter.formatEditUpdate(_value(old), _value(next));
+      expect(result.text, next);
+    });
+  });
+
+  group('EmailTextInputJsonFormatter rejected input', () {
+    test('rejects a leading special atom character', () {
+      final result = formatter.formatEditUpdate(_value(''), _value('!'));
+      expect(result.text, '');
+    });
+
+    test('rejects extending text that starts with an atom character', () {
+      // Even though "!a" is longer, the leading atom char is re-checked.
+      final result = formatter.formatEditUpdate(_value('!'), _value('!a'));
+      expect(result.text, '!');
+    });
+
+    test('rejects a second @', () {
+      final result =
+          formatter.formatEditUpdate(_value('a@b'), _value('a@b@'));
+      expect(result.text, 'a@b');
+    });
+
+    test('rejects reaching the 255 character limit', () {
+      final old = 'a' * 254;
+      final next = 'a' * 255;
+      final result = formatter.formatEditUpdate(_value(old), _value(next));
+      expect(result.text, old);
+    });
+
+    test('rejects a paste longer than the limit', () {
+      final next = 'a' * 300;
+      final result = formatter.formatEditUpdate(_value(''), _value(next));
+      expect(result.text, '');
+    });
+  });
+
+  group('EmailTextInputJsonFormatter deletions', () {
+    test('pure deletion of a trailing character passes through', () {
+      final result = formatter.formatEditUpdate(_value('abc'), _value('ab'));
+      expect(result.text, 'ab');
+    });
+
+    test('pure deletion of a middle range passes through', () {
+      final result =
+          formatter.formatEditUpdate(_value('abcde'), _value('ae'));
+      expect(result.text, 'ae');
+    });
+
+    test('clearing the whole field passes through', () {
+      final result = formatter.formatEditUpdate(_value('abc'), _value(''));
+      expect(result.text, '');
+    });
+
+    test('deleting a leading char to expose an atom char is allowed', () {
+      // Deleting the "a" leaves "!b" which starts with an atom char, but a
+      // pure deletion is always permitted.
+      final result = formatter.formatEditUpdate(_value('a!b'), _value('!b'));
+      expect(result.text, '!b');
+    });
+
+    test('a shrinking selection-replace is still validated', () {
+      // Replacing all of "abcdef" with "@@" shrinks the text but is not a
+      // pure deletion, so the two-@ rule still rejects it.
+      final result =
+          formatter.formatEditUpdate(_value('abcdef'), _value('@@'));
+      expect(result.text, 'abcdef');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds unit test coverage for the three `TextInputFormatter` implementations in `lib/src/utils/`, which previously had none:

- **`EmailTextInputJsonFormatter`** (`test/email_text_input_json_formatter_test.dart`) — valid input (typing a full email, single `@`, atom chars away from the start), rejected input (leading atom char, second `@`, 255-char limit, oversized paste), and deletion pass-through (trailing/middle deletion, clearing, exposing a leading atom char, and a shrinking selection-replace that is still validated).
- **`DateTextInputJsonFormatter`** (`test/date_text_input_json_formatter_test.dart`) — progressive `DD-MM-YYYY` masking with eager separator insertion, a fully typed valid date, rejection of out-of-range day/month digits and over-length input, and deletion pass-through.
- **`DefaultTextInputJsonFormatter`** (`test/default_text_input_json_formatter_test.dart`) — no-pattern behavior (regular chars accepted, lone newline rejected), pattern behavior (match accepted, non-match rejected, partial/contains semantics), caret placement, and deletion pass-through.

Tests were written against the exact current behavior of each formatter, including the eager double-separator behavior of the date mask, so they document what the code does today.

## Testing

⚠️ The Flutter SDK is not available in this environment, so the tests could not be executed here. They should be run with `flutter test` before merge. Each test's expectations were derived by tracing the formatter logic by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXFh2VEs5Tu7cAFvSRP63A

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXFh2VEs5Tu7cAFvSRP63A)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/doneservices/codesmith/flutter_jsonschema_builder/pr/18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786200204&installation_id=141069855&pr_number=18&repository=doneservices%2Fflutter_jsonschema_builder&return_to=https%3A%2F%2Fgithub.com%2Fdoneservices%2Fflutter_jsonschema_builder%2Fpull%2F18&signature=17166b9d3e0fcf3cf7038cc406dbdcd9df73367bdcecbd11b199168ebb172154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added widget test suites for text input formatter behavior.
  * Covered date formatting across incremental typing, invalid sequences, and deletion/clearing scenarios (including caret/selection placement).
  * Covered default formatter behavior with and without regex patterns, including acceptance/rejection rules and newline handling.
  * Covered email formatter typing acceptance, rejection rules (including `@` and length limits), and deletion passthrough behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->