### PR TITLE
Add RJSF-compatible conditional forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.2.0
 
+* Added RJSF-compatible conditional fields using JSON Schema
+  `if`/`then`/`else`, directly or inside `allOf`, in both display modes
 * Added `JsonFormDisplayMode.stepped`: a step-by-step display mode with
   progress bar, per-step validation, vertical/horizontal transitions and an
   optional review step (`JsonFormSteppedConfig`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
-## 0.2.0
+## 0.3.0
 
 * Added RJSF-compatible conditional fields using JSON Schema
   `if`/`then`/`else`, directly or inside `allOf`, in both display modes
+
+## 0.2.0
+
 * Added `JsonFormDisplayMode.stepped`: a step-by-step display mode with
   progress bar, per-step validation, vertical/horizontal transitions and an
   optional review step (`JsonFormSteppedConfig`)

--- a/README.md
+++ b/README.md
@@ -117,6 +117,39 @@ final uiSchema = '''
 ```
 <img width="348" alt="image" src="https://user-images.githubusercontent.com/58694638/187996261-ab3be73d-35e0-40c5-a0de-47900b64f1be.png">
 
+### Conditional fields
+
+Conditional fields use the same JSON Schema annotations as RJSF. Put
+`if`/`then`/`else` directly on an object, or wrap rules in `allOf`. Active
+branches can add properties and make them required; classic and stepped modes
+update automatically.
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "pet": {"type": "string", "enum": ["none", "cat"]}
+  },
+  "allOf": [{
+    "if": {
+      "required": ["pet"],
+      "properties": {"pet": {"const": "cat"}}
+    },
+    "then": {
+      "properties": {
+        "petName": {"type": "string", "title": "Pet name"}
+      },
+      "required": ["petName"]
+    }
+  }]
+}
+```
+
+Conditions support the common JSON Schema predicates `const`, `enum`,
+`required`, nested `properties`, `type`, `not`, `allOf`, `anyOf`, `oneOf`,
+string length/pattern, and numeric bounds. The earlier RJSF-compatible
+`dependencies` syntax remains supported.
+
 
 ### Stepped display mode
 
@@ -350,4 +383,3 @@ customValidatorHandler: () => {
 - [ ] OnChanged
 - [ ] References
 - [ ] pub.dev
-

--- a/lib/src/builder/logic/object_schema_logic.dart
+++ b/lib/src/builder/logic/object_schema_logic.dart
@@ -24,11 +24,14 @@ class ObjectSchemaInherited extends InheritedWidget {
   final ValueSetter<ObjectSchemaEvent?> listen;
 
   static ObjectSchemaInherited of(BuildContext context) {
-    final ObjectSchemaInherited? result =
-        context.dependOnInheritedWidgetOfExactType<ObjectSchemaInherited>();
+    final ObjectSchemaInherited? result = context
+        .dependOnInheritedWidgetOfExactType<ObjectSchemaInherited>();
     assert(result != null, 'No WidgetBuilderInherited found in context');
     return result!;
   }
+
+  static ObjectSchemaInherited? maybeOf(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<ObjectSchemaInherited>();
 
   @override
   bool updateShouldNotify(covariant ObjectSchemaInherited oldWidget) {
@@ -37,8 +40,13 @@ class ObjectSchemaInherited extends InheritedWidget {
   }
 
   /// esta funcion comunica
-  void listenChangeProperty(bool active, SchemaProperty schemaProperty,
-      {dynamic optionalValue, Schema? mainSchema, String? idOptional}) async {
+  void listenChangeProperty(
+    bool active,
+    SchemaProperty schemaProperty, {
+    dynamic optionalValue,
+    Schema? mainSchema,
+    String? idOptional,
+  }) async {
     try {
       // Eliminamos los nuevos imputs agregados
       await _removeCreatedItemsSafeMode(schemaProperty);
@@ -73,7 +81,8 @@ class ObjectSchemaInherited extends InheritedWidget {
           for (Map<String, dynamic> oneOf in oneOfs) {
             // Verificamos si es el que requerimos
             if (oneOf.containsKey('properties') &&
-                !oneOf['properties'].containsKey(schemaProperty.id)) continue;
+                !oneOf['properties'].containsKey(schemaProperty.id))
+              continue;
 
             // Verificamos que tenga la estructura enum correcta
             if (oneOf['properties'][schemaProperty.id] is! Map ||
@@ -102,17 +111,20 @@ class ObjectSchemaInherited extends InheritedWidget {
                   .where((e) => e.id != schemaProperty.id)
                   // Agregamos que fue dependiente de este, para que luego pueda ser eliminado.
                   .map((e) {
-                e.dependentsAddedBy.addAll([
-                  ...schemaProperty.dependentsAddedBy,
-                  schemaProperty.id,
-                ]);
-                if (e is SchemaProperty) e.setDependents(schemaObject);
+                    e.dependentsAddedBy.addAll([
+                      ...schemaProperty.dependentsAddedBy,
+                      schemaProperty.id,
+                    ]);
+                    if (e is SchemaProperty) e.setDependents(schemaObject);
 
-                return e;
-              }).toList();
+                    return e;
+                  })
+                  .toList();
 
-              schemaObject.properties!
-                  .insertAll(indexProperty + 1, newProperties);
+              schemaObject.properties!.insertAll(
+                indexProperty + 1,
+                newProperties,
+              );
             }
           }
         }
@@ -129,8 +141,9 @@ class ObjectSchemaInherited extends InheritedWidget {
         } else {
           // match by raw id: idKey is path-qualified for nested objects and
           // would never match, leaving the dependent field stuck in the form
-          schemaObject.properties!
-              .removeWhere((element) => element.id == schema.id);
+          schemaObject.properties!.removeWhere(
+            (element) => element.id == schema.id,
+          );
         }
 
         schemaProperty.isDependentsActive = active;
@@ -143,7 +156,8 @@ class ObjectSchemaInherited extends InheritedWidget {
   }
 
   Future<void> _removeCreatedItemsSafeMode(
-      SchemaProperty schemaProperty) async {
+    SchemaProperty schemaProperty,
+  ) async {
     bool filter(Schema element) =>
         (element).dependentsAddedBy.contains(schemaProperty.id);
 

--- a/lib/src/builder/logic/object_schema_logic.dart
+++ b/lib/src/builder/logic/object_schema_logic.dart
@@ -24,8 +24,8 @@ class ObjectSchemaInherited extends InheritedWidget {
   final ValueSetter<ObjectSchemaEvent?> listen;
 
   static ObjectSchemaInherited of(BuildContext context) {
-    final ObjectSchemaInherited? result = context
-        .dependOnInheritedWidgetOfExactType<ObjectSchemaInherited>();
+    final ObjectSchemaInherited? result =
+        context.dependOnInheritedWidgetOfExactType<ObjectSchemaInherited>();
     assert(result != null, 'No WidgetBuilderInherited found in context');
     return result!;
   }
@@ -40,13 +40,8 @@ class ObjectSchemaInherited extends InheritedWidget {
   }
 
   /// esta funcion comunica
-  void listenChangeProperty(
-    bool active,
-    SchemaProperty schemaProperty, {
-    dynamic optionalValue,
-    Schema? mainSchema,
-    String? idOptional,
-  }) async {
+  void listenChangeProperty(bool active, SchemaProperty schemaProperty,
+      {dynamic optionalValue, Schema? mainSchema, String? idOptional}) async {
     try {
       // Eliminamos los nuevos imputs agregados
       await _removeCreatedItemsSafeMode(schemaProperty);
@@ -81,8 +76,7 @@ class ObjectSchemaInherited extends InheritedWidget {
           for (Map<String, dynamic> oneOf in oneOfs) {
             // Verificamos si es el que requerimos
             if (oneOf.containsKey('properties') &&
-                !oneOf['properties'].containsKey(schemaProperty.id))
-              continue;
+                !oneOf['properties'].containsKey(schemaProperty.id)) continue;
 
             // Verificamos que tenga la estructura enum correcta
             if (oneOf['properties'][schemaProperty.id] is! Map ||
@@ -111,20 +105,17 @@ class ObjectSchemaInherited extends InheritedWidget {
                   .where((e) => e.id != schemaProperty.id)
                   // Agregamos que fue dependiente de este, para que luego pueda ser eliminado.
                   .map((e) {
-                    e.dependentsAddedBy.addAll([
-                      ...schemaProperty.dependentsAddedBy,
-                      schemaProperty.id,
-                    ]);
-                    if (e is SchemaProperty) e.setDependents(schemaObject);
+                e.dependentsAddedBy.addAll([
+                  ...schemaProperty.dependentsAddedBy,
+                  schemaProperty.id,
+                ]);
+                if (e is SchemaProperty) e.setDependents(schemaObject);
 
-                    return e;
-                  })
-                  .toList();
+                return e;
+              }).toList();
 
-              schemaObject.properties!.insertAll(
-                indexProperty + 1,
-                newProperties,
-              );
+              schemaObject.properties!
+                  .insertAll(indexProperty + 1, newProperties);
             }
           }
         }
@@ -141,9 +132,8 @@ class ObjectSchemaInherited extends InheritedWidget {
         } else {
           // match by raw id: idKey is path-qualified for nested objects and
           // would never match, leaving the dependent field stuck in the form
-          schemaObject.properties!.removeWhere(
-            (element) => element.id == schema.id,
-          );
+          schemaObject.properties!
+              .removeWhere((element) => element.id == schema.id);
         }
 
         schemaProperty.isDependentsActive = active;
@@ -156,8 +146,7 @@ class ObjectSchemaInherited extends InheritedWidget {
   }
 
   Future<void> _removeCreatedItemsSafeMode(
-    SchemaProperty schemaProperty,
-  ) async {
+      SchemaProperty schemaProperty) async {
     bool filter(Schema element) =>
         (element).dependentsAddedBy.contains(schemaProperty.id);
 

--- a/lib/src/builder/object_schema_builder.dart
+++ b/lib/src/builder/object_schema_builder.dart
@@ -31,11 +31,13 @@ class _ObjectSchemaBuilderState extends State<ObjectSchemaBuilder> {
 
   @override
   Widget build(BuildContext context) {
+    final parentScope = ObjectSchemaInherited.maybeOf(context);
     return ObjectSchemaInherited(
       schemaObject: _schemaObject,
       listen: (value) {
         if (value is ObjectSchemaDependencyEvent) {
-          setState(() => _schemaObject = value.schemaObject);
+          setState(() {});
+          parentScope?.listen(value);
         }
       },
       child: Column(

--- a/lib/src/builder/object_schema_builder.dart
+++ b/lib/src/builder/object_schema_builder.dart
@@ -21,19 +21,11 @@ class ObjectSchemaBuilder extends StatefulWidget {
 }
 
 class _ObjectSchemaBuilderState extends State<ObjectSchemaBuilder> {
-  late SchemaObject _schemaObject;
-
-  @override
-  void initState() {
-    super.initState();
-    _schemaObject = widget.schemaObject;
-  }
-
   @override
   Widget build(BuildContext context) {
     final parentScope = ObjectSchemaInherited.maybeOf(context);
     return ObjectSchemaInherited(
-      schemaObject: _schemaObject,
+      schemaObject: widget.schemaObject,
       listen: (value) {
         if (value is ObjectSchemaDependencyEvent) {
           setState(() {});

--- a/lib/src/builder/object_schema_builder.dart
+++ b/lib/src/builder/object_schema_builder.dart
@@ -28,7 +28,7 @@ class _ObjectSchemaBuilderState extends State<ObjectSchemaBuilder> {
       schemaObject: widget.schemaObject,
       listen: (value) {
         if (value is ObjectSchemaDependencyEvent) {
-          setState(() {});
+          if (mounted) setState(() {});
           parentScope?.listen(value);
         }
       },

--- a/lib/src/builder/property_schema_builder.dart
+++ b/lib/src/builder/property_schema_builder.dart
@@ -322,6 +322,14 @@ class PropertySchemaBuilder extends StatelessWidget {
       schemaProperty.idKey,
       val,
     );
+    final objectScope = ObjectSchemaInherited.of(context);
+    if ((mainSchema as SchemaObject).resolveConditions(
+      widgetBuilderInherited.data,
+    )) {
+      objectScope.listen(
+        ObjectSchemaDependencyEvent(schemaObject: objectScope.schemaObject),
+      );
+    }
   }
 
   // @temp Functions

--- a/lib/src/builder/widget_builder.dart
+++ b/lib/src/builder/widget_builder.dart
@@ -102,11 +102,11 @@ class JsonForm extends StatefulWidget {
   /// is [JsonFormDisplayMode.stepped]
   final JsonFormSteppedConfig steppedConfig;
 
-  /// whether to show the form's top-level title (and description) taken from
-  /// the schema.
+  /// whether to show the form's top-level header taken from the schema.
   ///
-  /// defaults to `true`; set to `false` to hide the form header. Applies to
-  /// both [JsonFormDisplayMode.fullForm] and [JsonFormDisplayMode.stepped].
+  /// In full-form mode, the header includes the title and description. In
+  /// stepped mode, it includes the title above the progress bar. Defaults to
+  /// `true`; set to `false` to hide the form header.
   final bool showTitle;
 
   @override

--- a/lib/src/builder/widget_builder.dart
+++ b/lib/src/builder/widget_builder.dart
@@ -25,17 +25,20 @@ enum JsonFormDisplayMode {
   stepped,
 }
 
-typedef FileHandler = Map<String,
-        Future<List<SchemaFormFile>?> Function(SchemaProperty property)?>
+typedef FileHandler =
+    Map<
+      String,
+      Future<List<SchemaFormFile>?> Function(SchemaProperty property)?
+    >
     Function();
-typedef InitialFileValueHandler
-    = Map<String, Future<List<SchemaFormFile>?> Function(dynamic defaultValue)?>
-        Function();
-typedef CustomPickerHandler
-    = Map<String, Future<dynamic> Function(SchemaProperty data)> Function();
+typedef InitialFileValueHandler =
+    Map<String, Future<List<SchemaFormFile>?> Function(dynamic defaultValue)?>
+    Function();
+typedef CustomPickerHandler =
+    Map<String, Future<dynamic> Function(SchemaProperty data)> Function();
 
-typedef CustomValidatorHandler = Map<String, String? Function(dynamic)?>
-    Function();
+typedef CustomValidatorHandler =
+    Map<String, String? Function(dynamic)?> Function();
 
 class JsonForm extends StatefulWidget {
   const JsonForm({
@@ -126,10 +129,17 @@ class _JsonFormState extends State<JsonForm> {
   @override
   void initState() {
     _formData = Map<String, dynamic>.from(widget.initialData ?? {});
-    mainSchema = (Schema.fromJson(json.decode(widget.jsonSchema),
-        id: kGenesisIdKey, initialData: widget.initialData) as SchemaObject)
-      ..setUiSchema(
-          widget.uiSchema != null ? json.decode(widget.uiSchema!) : null);
+    mainSchema =
+        (Schema.fromJson(
+                json.decode(widget.jsonSchema),
+                id: kGenesisIdKey,
+                initialData: widget.initialData,
+              )
+              as SchemaObject)
+          ..setUiSchema(
+            widget.uiSchema != null ? json.decode(widget.uiSchema!) : null,
+          );
+    mainSchema.resolveConditions(_formData);
 
     super.initState();
   }
@@ -146,53 +156,56 @@ class _JsonFormState extends State<JsonForm> {
       initialData: _formData,
       inputDecoration: widget.inputDecoration,
       displayMode: widget.displayMode,
-      child: Builder(builder: (context) {
-        final widgetBuilderInherited = WidgetBuilderInherited.of(context);
+      child: Builder(
+        builder: (context) {
+          final widgetBuilderInherited = WidgetBuilderInherited.of(context);
 
-        if (widget.displayMode == JsonFormDisplayMode.stepped) {
-          return SteppedFormBuilder(
-            mainSchema: mainSchema,
-            config: widget.steppedConfig,
-            showDebugElements: widget.showDebugElements,
-            padding: widget.padding,
-            showTitle: widget.showTitle,
-            onSubmit: () =>
-                widget.onFormDataSaved(widgetBuilderInherited.data),
-          );
-        }
+          if (widget.displayMode == JsonFormDisplayMode.stepped) {
+            return SteppedFormBuilder(
+              mainSchema: mainSchema,
+              config: widget.steppedConfig,
+              showDebugElements: widget.showDebugElements,
+              padding: widget.padding,
+              showTitle: widget.showTitle,
+              onSubmit: () =>
+                  widget.onFormDataSaved(widgetBuilderInherited.data),
+            );
+          }
 
-        return Form(
-          key: _formKey,
-          child: Container(
-            padding: widget.padding,
-            child: Column(
-              children: <Widget>[
-                if (!kReleaseMode && widget.showDebugElements)
-                  TextButton(
-                    onPressed: () {
-                      inspect(mainSchema);
-                    },
-                    child: const Text('INSPECT'),
+          return Form(
+            key: _formKey,
+            child: Container(
+              padding: widget.padding,
+              child: Column(
+                children: <Widget>[
+                  if (!kReleaseMode && widget.showDebugElements)
+                    TextButton(
+                      onPressed: () {
+                        inspect(mainSchema);
+                      },
+                      child: const Text('INSPECT'),
+                    ),
+                  if (widget.showTitle) _buildHeaderTitle(context),
+                  FormFromSchemaBuilder(
+                    mainSchema: mainSchema,
+                    schema: mainSchema,
+                    showDebugElements: widget.showDebugElements,
                   ),
-                if (widget.showTitle) _buildHeaderTitle(context),
-                FormFromSchemaBuilder(
-                  mainSchema: mainSchema,
-                  schema: mainSchema,
-                  showDebugElements: widget.showDebugElements,
-                ),
-                const SizedBox(height: 20),
-                widgetBuilderInherited.uiConfig.submitButtonBuilder == null
-                    ? ElevatedButton(
-                        onPressed: () => onSubmit(widgetBuilderInherited),
-                        child: const Text('Submit'),
-                      )
-                    : widgetBuilderInherited.uiConfig.submitButtonBuilder!(
-                        () => onSubmit(widgetBuilderInherited)),
-              ],
+                  const SizedBox(height: 20),
+                  widgetBuilderInherited.uiConfig.submitButtonBuilder == null
+                      ? ElevatedButton(
+                          onPressed: () => onSubmit(widgetBuilderInherited),
+                          child: const Text('Submit'),
+                        )
+                      : widgetBuilderInherited.uiConfig.submitButtonBuilder!(
+                          () => onSubmit(widgetBuilderInherited),
+                        ),
+                ],
+              ),
             ),
-          ),
-        );
-      }),
+          );
+        },
+      ),
     )..setJsonFormSchemaStyle(context, widget.jsonFormSchemaUiConfig);
   }
 

--- a/lib/src/builder/widget_builder.dart
+++ b/lib/src/builder/widget_builder.dart
@@ -25,20 +25,17 @@ enum JsonFormDisplayMode {
   stepped,
 }
 
-typedef FileHandler =
-    Map<
-      String,
-      Future<List<SchemaFormFile>?> Function(SchemaProperty property)?
-    >
+typedef FileHandler = Map<String,
+        Future<List<SchemaFormFile>?> Function(SchemaProperty property)?>
     Function();
-typedef InitialFileValueHandler =
-    Map<String, Future<List<SchemaFormFile>?> Function(dynamic defaultValue)?>
-    Function();
-typedef CustomPickerHandler =
-    Map<String, Future<dynamic> Function(SchemaProperty data)> Function();
+typedef InitialFileValueHandler
+    = Map<String, Future<List<SchemaFormFile>?> Function(dynamic defaultValue)?>
+        Function();
+typedef CustomPickerHandler
+    = Map<String, Future<dynamic> Function(SchemaProperty data)> Function();
 
-typedef CustomValidatorHandler =
-    Map<String, String? Function(dynamic)?> Function();
+typedef CustomValidatorHandler = Map<String, String? Function(dynamic)?>
+    Function();
 
 class JsonForm extends StatefulWidget {
   const JsonForm({
@@ -129,16 +126,10 @@ class _JsonFormState extends State<JsonForm> {
   @override
   void initState() {
     _formData = Map<String, dynamic>.from(widget.initialData ?? {});
-    mainSchema =
-        (Schema.fromJson(
-                json.decode(widget.jsonSchema),
-                id: kGenesisIdKey,
-                initialData: widget.initialData,
-              )
-              as SchemaObject)
-          ..setUiSchema(
-            widget.uiSchema != null ? json.decode(widget.uiSchema!) : null,
-          );
+    mainSchema = (Schema.fromJson(json.decode(widget.jsonSchema),
+        id: kGenesisIdKey, initialData: widget.initialData) as SchemaObject)
+      ..setUiSchema(
+          widget.uiSchema != null ? json.decode(widget.uiSchema!) : null);
     mainSchema.resolveConditions(_formData);
 
     super.initState();
@@ -156,56 +147,53 @@ class _JsonFormState extends State<JsonForm> {
       initialData: _formData,
       inputDecoration: widget.inputDecoration,
       displayMode: widget.displayMode,
-      child: Builder(
-        builder: (context) {
-          final widgetBuilderInherited = WidgetBuilderInherited.of(context);
+      child: Builder(builder: (context) {
+        final widgetBuilderInherited = WidgetBuilderInherited.of(context);
 
-          if (widget.displayMode == JsonFormDisplayMode.stepped) {
-            return SteppedFormBuilder(
-              mainSchema: mainSchema,
-              config: widget.steppedConfig,
-              showDebugElements: widget.showDebugElements,
-              padding: widget.padding,
-              showTitle: widget.showTitle,
-              onSubmit: () =>
-                  widget.onFormDataSaved(widgetBuilderInherited.data),
-            );
-          }
-
-          return Form(
-            key: _formKey,
-            child: Container(
-              padding: widget.padding,
-              child: Column(
-                children: <Widget>[
-                  if (!kReleaseMode && widget.showDebugElements)
-                    TextButton(
-                      onPressed: () {
-                        inspect(mainSchema);
-                      },
-                      child: const Text('INSPECT'),
-                    ),
-                  if (widget.showTitle) _buildHeaderTitle(context),
-                  FormFromSchemaBuilder(
-                    mainSchema: mainSchema,
-                    schema: mainSchema,
-                    showDebugElements: widget.showDebugElements,
-                  ),
-                  const SizedBox(height: 20),
-                  widgetBuilderInherited.uiConfig.submitButtonBuilder == null
-                      ? ElevatedButton(
-                          onPressed: () => onSubmit(widgetBuilderInherited),
-                          child: const Text('Submit'),
-                        )
-                      : widgetBuilderInherited.uiConfig.submitButtonBuilder!(
-                          () => onSubmit(widgetBuilderInherited),
-                        ),
-                ],
-              ),
-            ),
+        if (widget.displayMode == JsonFormDisplayMode.stepped) {
+          return SteppedFormBuilder(
+            mainSchema: mainSchema,
+            config: widget.steppedConfig,
+            showDebugElements: widget.showDebugElements,
+            padding: widget.padding,
+            showTitle: widget.showTitle,
+            onSubmit: () =>
+                widget.onFormDataSaved(widgetBuilderInherited.data),
           );
-        },
-      ),
+        }
+
+        return Form(
+          key: _formKey,
+          child: Container(
+            padding: widget.padding,
+            child: Column(
+              children: <Widget>[
+                if (!kReleaseMode && widget.showDebugElements)
+                  TextButton(
+                    onPressed: () {
+                      inspect(mainSchema);
+                    },
+                    child: const Text('INSPECT'),
+                  ),
+                if (widget.showTitle) _buildHeaderTitle(context),
+                FormFromSchemaBuilder(
+                  mainSchema: mainSchema,
+                  schema: mainSchema,
+                  showDebugElements: widget.showDebugElements,
+                ),
+                const SizedBox(height: 20),
+                widgetBuilderInherited.uiConfig.submitButtonBuilder == null
+                    ? ElevatedButton(
+                        onPressed: () => onSubmit(widgetBuilderInherited),
+                        child: const Text('Submit'),
+                      )
+                    : widgetBuilderInherited.uiConfig.submitButtonBuilder!(
+                        () => onSubmit(widgetBuilderInherited)),
+              ],
+            ),
+          ),
+        );
+      }),
     )..setJsonFormSchemaStyle(context, widget.jsonFormSchemaUiConfig);
   }
 

--- a/lib/src/models/conditional_schema.dart
+++ b/lib/src/models/conditional_schema.dart
@@ -5,7 +5,13 @@ bool jsonSchemaMatches(dynamic schema, dynamic data) {
   // Number fields currently store their text input in formData. Coerce only
   // when the condition itself is numeric, preserving ordinary string rules.
   if (data is String && _usesNumericComparison(schema)) {
-    data = num.tryParse(data.replaceAll(',', '.')) ?? data;
+    final values = schema['enum'];
+    final hasExactMatch =
+        (schema.containsKey('const') && _jsonEquals(data, schema['const'])) ||
+        (values is List && values.any((value) => _jsonEquals(data, value)));
+    if (!hasExactMatch) {
+      data = num.tryParse(data.replaceAll(',', '.')) ?? data;
+    }
   }
 
   if (schema.containsKey('const') && !_jsonEquals(data, schema['const'])) {

--- a/lib/src/models/conditional_schema.dart
+++ b/lib/src/models/conditional_schema.dart
@@ -91,7 +91,13 @@ bool jsonSchemaMatches(dynamic schema, dynamic data) {
 }
 
 bool _usesNumericComparison(Map schema) {
-  if (schema['type'] == 'number' || schema['type'] == 'integer') return true;
+  final type = schema['type'];
+  if (type == 'number' ||
+      type == 'integer' ||
+      (type is List &&
+          type.any((item) => item == 'number' || item == 'integer'))) {
+    return true;
+  }
   if (schema['const'] is num) return true;
   if (schema['enum'] is List && (schema['enum'] as List).any((v) => v is num)) {
     return true;

--- a/lib/src/models/conditional_schema.dart
+++ b/lib/src/models/conditional_schema.dart
@@ -1,0 +1,134 @@
+bool jsonSchemaMatches(dynamic schema, dynamic data) {
+  if (schema is bool) return schema;
+  if (schema is! Map) return true;
+
+  // Number fields currently store their text input in formData. Coerce only
+  // when the condition itself is numeric, preserving ordinary string rules.
+  if (data is String && _usesNumericComparison(schema)) {
+    data = num.tryParse(data.replaceAll(',', '.')) ?? data;
+  }
+
+  if (schema.containsKey('const') && !_jsonEquals(data, schema['const'])) {
+    return false;
+  }
+
+  final values = schema['enum'];
+  if (values is List && !values.any((value) => _jsonEquals(data, value))) {
+    return false;
+  }
+
+  final type = schema['type'];
+  if (type != null && !_matchesType(type, data)) return false;
+
+  final required = schema['required'];
+  if (required is List &&
+      (data is! Map || required.any((key) => !data.containsKey(key)))) {
+    return false;
+  }
+
+  final properties = schema['properties'];
+  if (properties is Map && data is Map) {
+    for (final entry in properties.entries) {
+      if (data.containsKey(entry.key) &&
+          !jsonSchemaMatches(entry.value, data[entry.key])) {
+        return false;
+      }
+    }
+  }
+
+  final allOf = schema['allOf'];
+  if (allOf is List && !allOf.every((item) => jsonSchemaMatches(item, data))) {
+    return false;
+  }
+
+  final anyOf = schema['anyOf'];
+  if (anyOf is List && !anyOf.any((item) => jsonSchemaMatches(item, data))) {
+    return false;
+  }
+
+  final oneOf = schema['oneOf'];
+  if (oneOf is List &&
+      oneOf.where((item) => jsonSchemaMatches(item, data)).length != 1) {
+    return false;
+  }
+
+  if (schema['not'] != null && jsonSchemaMatches(schema['not'], data)) {
+    return false;
+  }
+
+  if (data is String) {
+    final minLength = schema['minLength'];
+    final maxLength = schema['maxLength'];
+    if (minLength is num && data.length < minLength) return false;
+    if (maxLength is num && data.length > maxLength) return false;
+    if (schema['pattern'] case final String pattern) {
+      try {
+        if (!RegExp(pattern).hasMatch(data)) return false;
+      } on FormatException {
+        return false;
+      }
+    }
+  }
+
+  if (data is num) {
+    final minimum = schema['minimum'];
+    final maximum = schema['maximum'];
+    final exclusiveMinimum = schema['exclusiveMinimum'];
+    final exclusiveMaximum = schema['exclusiveMaximum'];
+    if (minimum is num && data < minimum) return false;
+    if (maximum is num && data > maximum) return false;
+    if (exclusiveMinimum is num && data <= exclusiveMinimum) return false;
+    if (exclusiveMaximum is num && data >= exclusiveMaximum) return false;
+  }
+
+  return true;
+}
+
+bool _usesNumericComparison(Map schema) {
+  if (schema['type'] == 'number' || schema['type'] == 'integer') return true;
+  if (schema['const'] is num) return true;
+  if (schema['enum'] is List && (schema['enum'] as List).any((v) => v is num)) {
+    return true;
+  }
+  return const [
+    'minimum',
+    'maximum',
+    'exclusiveMinimum',
+    'exclusiveMaximum',
+  ].any(schema.containsKey);
+}
+
+bool _matchesType(dynamic type, dynamic data) {
+  if (type is List) return type.any((item) => _matchesType(item, data));
+
+  return switch (type) {
+    'null' => data == null,
+    'boolean' => data is bool,
+    'object' => data is Map,
+    'array' => data is List,
+    'number' => data is num,
+    'integer' =>
+      data is int || (data is double && data == data.roundToDouble()),
+    'string' => data is String,
+    _ => true,
+  };
+}
+
+bool _jsonEquals(dynamic left, dynamic right) {
+  if (left is List && right is List) {
+    if (left.length != right.length) return false;
+    for (var i = 0; i < left.length; i++) {
+      if (!_jsonEquals(left[i], right[i])) return false;
+    }
+    return true;
+  }
+  if (left is Map && right is Map) {
+    return left.length == right.length &&
+        left.entries.every(
+          (entry) =>
+              right.containsKey(entry.key) &&
+              _jsonEquals(entry.value, right[entry.key]),
+        );
+  }
+  return left == right;
+}

--- a/lib/src/models/object_schema.dart
+++ b/lib/src/models/object_schema.dart
@@ -247,7 +247,9 @@ class SchemaObject extends Schema {
             final original = properties![index];
             if (property is SchemaProperty && original is SchemaProperty) {
               property.isDependentsActive = original.isDependentsActive;
-            } else if (property is SchemaArray && original is SchemaArray) {
+            } else if (property is SchemaArray &&
+                original is SchemaArray &&
+                !entry.value.containsKey('items')) {
               property.items = original.items;
             }
             _conditionalOverrides[entry.key] = original;

--- a/lib/src/models/object_schema.dart
+++ b/lib/src/models/object_schema.dart
@@ -215,7 +215,8 @@ class SchemaObject extends Schema {
           }
         }
 
-        properties?.addAll(_conditionalProperties);
+        properties ??= <Schema>[];
+        properties!.addAll(_conditionalProperties);
         if (_uiSchema != null) setUiSchema(_uiSchema);
         final dependencyRequired = <String>{
           for (final property

--- a/lib/src/models/object_schema.dart
+++ b/lib/src/models/object_schema.dart
@@ -1,4 +1,5 @@
 import '../models/models.dart';
+import 'conditional_schema.dart';
 
 class SchemaObject extends Schema {
   SchemaObject({
@@ -7,10 +8,7 @@ class SchemaObject extends Schema {
     this.dependencies,
     String? title,
     super.description,
-  }) : super(
-          title: title ?? 'no-title',
-          type: SchemaType.object,
-        );
+  }) : super(title: title ?? 'no-title', type: SchemaType.object);
 
   factory SchemaObject.fromJson(
     String id,
@@ -27,6 +25,7 @@ class SchemaObject extends Schema {
           : [],
       dependencies: json['dependencies'],
     );
+    schema._conditionalRules = _readConditionalRules(json);
     schema.parentIdKey = parent?.idKey;
 
     schema.dependentsAddedBy.addAll(parent?.dependentsAddedBy ?? []);
@@ -70,11 +69,7 @@ class SchemaObject extends Schema {
     String? parentIdKey,
     List<String>? dependentsAddedBy,
   }) {
-    var newSchema = SchemaObject(
-      id: id,
-      title: title,
-      description: description,
-    )
+    var newSchema = SchemaObject(id: id, title: title, description: description)
       ..parentIdKey = parentIdKey ?? this.parentIdKey
       ..dependentsAddedBy = dependentsAddedBy ?? this.dependentsAddedBy
       ..type = type
@@ -87,11 +82,13 @@ class SchemaObject extends Schema {
     final otherProperties = properties!; //.map((p) => p.copyWith(id: p.id));
 
     newSchema.properties = otherProperties
-        .map((e) => e.copyWith(
-              id: e.id,
-              parentIdKey: newSchema.idKey,
-              dependentsAddedBy: newSchema.dependentsAddedBy,
-            ))
+        .map(
+          (e) => e.copyWith(
+            id: e.id,
+            parentIdKey: newSchema.idKey,
+            dependentsAddedBy: newSchema.dependentsAddedBy,
+          ),
+        )
         .toList();
 
     return newSchema;
@@ -115,8 +112,14 @@ class SchemaObject extends Schema {
   /// A [Schema] with [oneOf] is valid if exactly one of the subschemas is valid.
   List<Schema>? oneOf;
 
+  List<Map<String, dynamic>> _conditionalRules = const [];
+  List<int> _activeConditionalBranches = const [];
+  List<Schema> _conditionalProperties = const [];
+  Map<String, dynamic>? _uiSchema;
+
   void setUiSchema(Map<String, dynamic>? uiSchema) {
     if (uiSchema == null) return;
+    _uiSchema = uiSchema;
     if (properties != null && properties!.isEmpty) return;
 
     // set UI Schema to this ObjectSchema
@@ -156,6 +159,88 @@ class SchemaObject extends Schema {
         });
       properties = [for (final entry in indexed) entry.value];
     }
+  }
+
+  /// Resolves JSON Schema `if`/`then`/`else` annotations against [data].
+  /// RJSF commonly places these rules in `allOf`, which is supported too.
+  bool resolveConditions(dynamic data) {
+    var changed = false;
+    if (_conditionalRules.isNotEmpty) {
+      final activeBranches = [
+        for (final rule in _conditionalRules)
+          jsonSchemaMatches(rule['if'], data)
+              ? (rule['then'] is Map ? 1 : 0)
+              : (rule['else'] is Map ? -1 : 0),
+      ];
+
+      if (!_sameBranches(activeBranches, _activeConditionalBranches)) {
+        changed = true;
+        _activeConditionalBranches = activeBranches;
+        properties?.removeWhere(_conditionalProperties.contains);
+        _conditionalProperties = [];
+
+        final conditionalRequired = <String>{};
+        final existingIds = {
+          for (final property in properties ?? const <Schema>[]) property.id,
+        };
+
+        for (var i = 0; i < _conditionalRules.length; i++) {
+          final branchName = activeBranches[i] == 1
+              ? 'then'
+              : activeBranches[i] == -1
+              ? 'else'
+              : null;
+          if (branchName == null) continue;
+
+          final branch = _conditionalRules[i][branchName];
+          if (branch is! Map) continue;
+          final branchJson = Map<String, dynamic>.from(branch);
+          conditionalRequired.addAll(
+            (branchJson['required'] as List?)?.map((id) => id.toString()) ??
+                const <String>[],
+          );
+
+          if (branchJson['properties'] is! Map) continue;
+          final parsed = SchemaObject.fromJson(
+            kNoIdKey,
+            branchJson,
+            parent: this,
+            initialData: data is Map ? Map<String, dynamic>.from(data) : null,
+          );
+
+          for (final property in parsed.properties ?? const <Schema>[]) {
+            if (!existingIds.add(property.id)) continue;
+            if (property is SchemaProperty) property.setDependents(this);
+            _conditionalProperties.add(property);
+          }
+        }
+
+        properties?.addAll(_conditionalProperties);
+        if (_uiSchema != null) setUiSchema(_uiSchema);
+        final dependencyRequired = <String>{
+          for (final property
+              in properties?.whereType<SchemaProperty>() ??
+                  const <SchemaProperty>[])
+            if (property.isDependentsActive && property.dependents is List)
+              ...(property.dependents as List).map((id) => id.toString()),
+        };
+        for (final property
+            in properties?.whereType<SchemaProperty>() ??
+                const <SchemaProperty>[]) {
+          property.required =
+              required.contains(property.id) ||
+              conditionalRequired.contains(property.id) ||
+              dependencyRequired.contains(property.id);
+        }
+      }
+    }
+
+    for (final child
+        in properties?.whereType<SchemaObject>() ?? const <SchemaObject>[]) {
+      final childData = data is Map ? data[child.id] : null;
+      changed = child.resolveConditions(childData) || changed;
+    }
+    return changed;
   }
 
   void setProperties(
@@ -200,13 +285,34 @@ class SchemaObject extends Schema {
     var oneOfs = <Schema>[];
     for (var element in oneOf) {
       print(element);
-      oneOfs.add(Schema.fromJson(
-        element,
-        parent: schema,
-        initialData: initialData,
-      ));
+      oneOfs.add(
+        Schema.fromJson(element, parent: schema, initialData: initialData),
+      );
     }
 
     this.oneOf = oneOfs;
   }
+}
+
+List<Map<String, dynamic>> _readConditionalRules(Map<String, dynamic> json) {
+  final rules = <Map<String, dynamic>>[];
+  if (json['if'] is Map) rules.add(Map<String, dynamic>.from(json));
+
+  final allOf = json['allOf'];
+  if (allOf is List) {
+    for (final item in allOf) {
+      if (item is Map && item['if'] is Map) {
+        rules.add(Map<String, dynamic>.from(item));
+      }
+    }
+  }
+  return rules;
+}
+
+bool _sameBranches(List<int> left, List<int> right) {
+  if (left.length != right.length) return false;
+  for (var i = 0; i < left.length; i++) {
+    if (left[i] != right[i]) return false;
+  }
+  return true;
 }

--- a/lib/src/models/object_schema.dart
+++ b/lib/src/models/object_schema.dart
@@ -26,6 +26,11 @@ class SchemaObject extends Schema {
       dependencies: json['dependencies'],
     );
     schema._conditionalRules = _readConditionalRules(json);
+    schema._basePropertySchemas = {
+      for (final entry in (json['properties'] as Map? ?? const {}).entries)
+        if (entry.value is Map)
+          entry.key.toString(): Map<String, dynamic>.from(entry.value),
+    };
     schema.parentIdKey = parent?.idKey;
 
     schema.dependentsAddedBy.addAll(parent?.dependentsAddedBy ?? []);
@@ -115,6 +120,8 @@ class SchemaObject extends Schema {
   List<Map<String, dynamic>> _conditionalRules = const [];
   List<int> _activeConditionalBranches = const [];
   List<Schema> _conditionalProperties = const [];
+  Map<String, Map<String, dynamic>> _basePropertySchemas = const {};
+  Map<String, Schema> _conditionalOverrides = const {};
   Map<String, dynamic>? _uiSchema;
 
   void setUiSchema(Map<String, dynamic>? uiSchema) {
@@ -176,13 +183,18 @@ class SchemaObject extends Schema {
       if (!_sameBranches(activeBranches, _activeConditionalBranches)) {
         changed = true;
         _activeConditionalBranches = activeBranches;
+        for (final entry in _conditionalOverrides.entries) {
+          final index = properties?.indexWhere(
+            (property) => property.id == entry.key,
+          );
+          if (index != null && index >= 0) properties![index] = entry.value;
+        }
+        _conditionalOverrides = {};
         properties?.removeWhere(_conditionalProperties.contains);
         _conditionalProperties = [];
 
         final conditionalRequired = <String>{};
-        final existingIds = {
-          for (final property in properties ?? const <Schema>[]) property.id,
-        };
+        final conditionalSchemas = <String, Map<String, dynamic>>{};
 
         for (var i = 0; i < _conditionalRules.length; i++) {
           final branchName = activeBranches[i] == 1
@@ -200,22 +212,50 @@ class SchemaObject extends Schema {
                 const <String>[],
           );
 
-          if (branchJson['properties'] is! Map) continue;
-          final parsed = SchemaObject.fromJson(
-            kNoIdKey,
-            branchJson,
-            parent: this,
-            initialData: data is Map ? Map<String, dynamic>.from(data) : null,
-          );
-
-          for (final property in parsed.properties ?? const <Schema>[]) {
-            if (!existingIds.add(property.id)) continue;
-            if (property is SchemaProperty) property.setDependents(this);
-            _conditionalProperties.add(property);
+          final branchProperties = branchJson['properties'];
+          if (branchProperties is! Map) continue;
+          for (final entry in branchProperties.entries) {
+            if (entry.value is! Map) continue;
+            final id = entry.key.toString();
+            final propertyJson = Map<String, dynamic>.from(entry.value);
+            conditionalSchemas[id] = conditionalSchemas.containsKey(id)
+                ? _mergeJsonSchemas(conditionalSchemas[id]!, propertyJson)
+                : propertyJson;
           }
         }
 
         properties ??= <Schema>[];
+        final initialData = data is Map
+            ? Map<String, dynamic>.from(data)
+            : null;
+        for (final entry in conditionalSchemas.entries) {
+          final index = properties!.indexWhere(
+            (property) => property.id == entry.key,
+          );
+          final baseJson = _basePropertySchemas[entry.key];
+          final property = Schema.fromJson(
+            baseJson == null
+                ? entry.value
+                : _mergeJsonSchemas(baseJson, entry.value),
+            id: entry.key,
+            parent: this,
+            initialData: initialData,
+          );
+          if (property is SchemaProperty) property.setDependents(this);
+
+          if (index >= 0 && baseJson != null) {
+            final original = properties![index];
+            if (property is SchemaProperty && original is SchemaProperty) {
+              property.isDependentsActive = original.isDependentsActive;
+            } else if (property is SchemaArray && original is SchemaArray) {
+              property.items = original.items;
+            }
+            _conditionalOverrides[entry.key] = original;
+            properties![index] = property;
+          } else if (index < 0) {
+            _conditionalProperties.add(property);
+          }
+        }
         properties!.addAll(_conditionalProperties);
         if (_uiSchema != null) setUiSchema(_uiSchema);
         final dependencyRequired = <String>{
@@ -225,13 +265,16 @@ class SchemaObject extends Schema {
             if (property.isDependentsActive && property.dependents is List)
               ...(property.dependents as List).map((id) => id.toString()),
         };
-        for (final property
-            in properties?.whereType<SchemaProperty>() ??
-                const <SchemaProperty>[]) {
-          property.required =
+        for (final property in properties ?? const <Schema>[]) {
+          final isRequired =
               required.contains(property.id) ||
               conditionalRequired.contains(property.id) ||
               dependencyRequired.contains(property.id);
+          if (property is SchemaProperty) {
+            property.required = isRequired;
+          } else if (property is SchemaArray) {
+            property.required = isRequired;
+          }
         }
       }
     }
@@ -316,4 +359,25 @@ bool _sameBranches(List<int> left, List<int> right) {
     if (left[i] != right[i]) return false;
   }
   return true;
+}
+
+Map<String, dynamic> _mergeJsonSchemas(
+  Map<String, dynamic> base,
+  Map<String, dynamic> overlay,
+) {
+  final merged = Map<String, dynamic>.from(base);
+  for (final entry in overlay.entries) {
+    final current = merged[entry.key];
+    if (entry.key == 'required' && current is List && entry.value is List) {
+      merged[entry.key] = {...current, ...entry.value as List}.toList();
+    } else if (current is Map && entry.value is Map) {
+      merged[entry.key] = _mergeJsonSchemas(
+        Map<String, dynamic>.from(current),
+        Map<String, dynamic>.from(entry.value),
+      );
+    } else {
+      merged[entry.key] = entry.value;
+    }
+  }
+  return merged;
 }

--- a/test/conditional_form_test.dart
+++ b/test/conditional_form_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_jsonschema_builder/flutter_jsonschema_builder.dart';
+import 'package:flutter_jsonschema_builder/src/models/conditional_schema.dart';
 import 'package:flutter_jsonschema_builder/src/models/models.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -120,6 +121,30 @@ void main() {
       'age',
       'adultName',
     ]);
+  });
+
+  test('numeric constraints preserve exact string const matches', () {
+    expect(jsonSchemaMatches({'const': '1', 'minimum': 0}, '1'), isTrue);
+  });
+
+  test('an object can contain only conditional properties', () {
+    final schema =
+        Schema.fromJson(
+              json.decode('''
+      {
+        "type": "object",
+        "if": {},
+        "then": {
+          "properties": {"conditional": {"type": "string"}}
+        }
+      }
+      '''),
+              id: kGenesisIdKey,
+            )
+            as SchemaObject;
+
+    schema.resolveConditions({});
+    expect(schema.properties!.single.id, 'conditional');
   });
 
   testWidgets('classic mode adds, validates, and removes a conditional field', (

--- a/test/conditional_form_test.dart
+++ b/test/conditional_form_test.dart
@@ -1,0 +1,228 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_jsonschema_builder/flutter_jsonschema_builder.dart';
+import 'package:flutter_jsonschema_builder/src/models/models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const conditionalSchema = '''
+{
+  "type": "object",
+  "properties": {
+    "pet": {
+      "type": "string",
+      "title": "Pet",
+      "enum": ["none", "cat"]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "required": ["pet"],
+        "properties": {"pet": {"const": "cat"}}
+      },
+      "then": {
+        "properties": {
+          "petName": {"type": "string", "title": "Pet name"}
+        },
+        "required": ["petName"]
+      }
+    }
+  ]
+}
+''';
+
+Widget testApp(JsonFormDisplayMode mode) {
+  final form = JsonForm(
+    jsonSchema: conditionalSchema,
+    displayMode: mode,
+    steppedConfig: const JsonFormSteppedConfig(autoAdvanceOnSelect: false),
+    onFormDataSaved: (_) {},
+  );
+  return MaterialApp(
+    home: Scaffold(
+      body: mode == JsonFormDisplayMode.stepped
+          ? SizedBox.expand(child: form)
+          : form,
+    ),
+  );
+}
+
+void main() {
+  test(
+    'direct if/then/else switches object properties and required fields',
+    () {
+      final schema =
+          Schema.fromJson(
+                json.decode('''
+      {
+        "type": "object",
+        "properties": {
+          "enabled": {"type": "boolean"}
+        },
+        "if": {
+          "required": ["enabled"],
+          "properties": {"enabled": {"const": true}}
+        },
+        "then": {
+          "properties": {"email": {"type": "string"}},
+          "required": ["email"]
+        },
+        "else": {
+          "properties": {"reason": {"type": "string"}}
+        }
+      }
+      '''),
+                id: kGenesisIdKey,
+              )
+              as SchemaObject;
+
+      schema.resolveConditions({});
+      expect(schema.properties!.map((property) => property.id), [
+        'enabled',
+        'reason',
+      ]);
+
+      schema.resolveConditions({'enabled': true});
+      expect(schema.properties!.map((property) => property.id), [
+        'enabled',
+        'email',
+      ]);
+      expect((schema.properties!.last as SchemaProperty).required, isTrue);
+    },
+  );
+
+  test('numeric conditions work with the form\'s text-backed number data', () {
+    final schema =
+        Schema.fromJson(
+              json.decode('''
+      {
+        "type": "object",
+        "properties": {"age": {"type": "integer"}},
+        "if": {
+          "required": ["age"],
+          "properties": {"age": {"minimum": 18}}
+        },
+        "then": {
+          "properties": {"adultName": {"type": "string"}}
+        }
+      }
+      '''),
+              id: kGenesisIdKey,
+            )
+            as SchemaObject;
+
+    schema.resolveConditions({'age': '17'});
+    expect(schema.properties!.map((property) => property.id), ['age']);
+
+    schema.resolveConditions({'age': '18'});
+    expect(schema.properties!.map((property) => property.id), [
+      'age',
+      'adultName',
+    ]);
+  });
+
+  testWidgets('classic mode adds, validates, and removes a conditional field', (
+    tester,
+  ) async {
+    await tester.pumpWidget(testApp(JsonFormDisplayMode.fullForm));
+    await tester.pump();
+
+    expect(find.byKey(const Key('petName')), findsNothing);
+
+    await tester.tap(find.byKey(const Key('pet')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('cat').last);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is TextFormField && widget.key == const Key('petName'),
+      ),
+      findsOneWidget,
+    );
+    await tester.tap(find.text('Submit'));
+    await tester.pumpAndSettle();
+    expect(find.text('Required'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('pet')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('none').last);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('petName')), findsNothing);
+  });
+
+  testWidgets('nested changes can activate a root condition', (tester) async {
+    const schema = '''
+    {
+      "type": "object",
+      "properties": {
+        "preferences": {
+          "type": "object",
+          "properties": {
+            "wantsEmail": {"type": "boolean", "title": "Email me"}
+          }
+        }
+      },
+      "if": {
+        "required": ["preferences"],
+        "properties": {
+          "preferences": {
+            "required": ["wantsEmail"],
+            "properties": {"wantsEmail": {"const": true}}
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "email": {"type": "string", "title": "Email"}
+        }
+      }
+    }
+    ''';
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: JsonForm(jsonSchema: schema, onFormDataSaved: (_) {}),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('email')), findsNothing);
+    await tester.tap(find.byKey(const Key('preferences.wantsEmail')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('email')), findsOneWidget);
+  });
+
+  testWidgets('stepped mode inserts and removes a conditional step', (
+    tester,
+  ) async {
+    await tester.pumpWidget(testApp(JsonFormDisplayMode.stepped));
+    await tester.pump();
+
+    expect(find.text('1 / 1'), findsOneWidget);
+    await tester.tap(find.text('cat').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('1 / 2'), findsOneWidget);
+    await tester.tap(find.text('Next'));
+    await tester.pumpAndSettle();
+    expect(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is TextFormField && widget.key == const Key('petName'),
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.text('Previous'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('none').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('1 / 1'), findsOneWidget);
+  });
+}

--- a/test/conditional_form_test.dart
+++ b/test/conditional_form_test.dart
@@ -150,7 +150,8 @@ void main() {
         },
         "then": {
           "properties": {
-            "code": {"title": "Conditional code", "pattern": "^A"}
+            "code": {"title": "Conditional code", "pattern": "^A"},
+            "items": {"items": {"type": "number"}}
           },
           "required": ["items"]
         }
@@ -160,17 +161,26 @@ void main() {
             )
             as SchemaObject;
 
+    final baseItems = schema.properties![2] as SchemaArray;
+    baseItems.items = [SchemaProperty(id: '0', type: SchemaType.string)];
+
     schema.resolveConditions({'enabled': true});
     final conditionalCode = schema.properties![1] as SchemaProperty;
+    final conditionalItems = schema.properties![2] as SchemaArray;
     expect(conditionalCode.title, 'Conditional code');
     expect(conditionalCode.pattern, '^A');
-    expect((schema.properties![2] as SchemaArray).required, isTrue);
+    expect(conditionalItems.required, isTrue);
+    expect(conditionalItems.items, isEmpty);
+    expect(conditionalItems.itemsBaseSchema['type'], 'number');
 
     schema.resolveConditions({'enabled': false});
     final baseCode = schema.properties![1] as SchemaProperty;
+    final restoredItems = schema.properties![2] as SchemaArray;
     expect(baseCode.title, 'Base code');
     expect(baseCode.pattern, isNull);
-    expect((schema.properties![2] as SchemaArray).required, isFalse);
+    expect(restoredItems.required, isFalse);
+    expect(restoredItems.items, hasLength(1));
+    expect(restoredItems.itemsBaseSchema['type'], 'string');
   });
 
   test('an object can contain only conditional properties', () {

--- a/test/conditional_form_test.dart
+++ b/test/conditional_form_test.dart
@@ -125,6 +125,52 @@ void main() {
 
   test('numeric constraints preserve exact string const matches', () {
     expect(jsonSchemaMatches({'const': '1', 'minimum': 0}, '1'), isTrue);
+    expect(
+      jsonSchemaMatches({
+        'type': ['number', 'null'],
+      }, '1'),
+      isTrue,
+    );
+  });
+
+  test('conditional branches merge and restore existing field schemas', () {
+    final schema =
+        Schema.fromJson(
+              json.decode('''
+      {
+        "type": "object",
+        "properties": {
+          "enabled": {"type": "boolean"},
+          "code": {"type": "string", "title": "Base code"},
+          "items": {"type": "array", "items": {"type": "string"}}
+        },
+        "if": {
+          "required": ["enabled"],
+          "properties": {"enabled": {"const": true}}
+        },
+        "then": {
+          "properties": {
+            "code": {"title": "Conditional code", "pattern": "^A"}
+          },
+          "required": ["items"]
+        }
+      }
+      '''),
+              id: kGenesisIdKey,
+            )
+            as SchemaObject;
+
+    schema.resolveConditions({'enabled': true});
+    final conditionalCode = schema.properties![1] as SchemaProperty;
+    expect(conditionalCode.title, 'Conditional code');
+    expect(conditionalCode.pattern, '^A');
+    expect((schema.properties![2] as SchemaArray).required, isTrue);
+
+    schema.resolveConditions({'enabled': false});
+    final baseCode = schema.properties![1] as SchemaProperty;
+    expect(baseCode.title, 'Base code');
+    expect(baseCode.pattern, isNull);
+    expect((schema.properties![2] as SchemaArray).required, isFalse);
   });
 
   test('an object can contain only conditional properties', () {


### PR DESCRIPTION
## Summary

- add RJSF-compatible `if`/`then`/`else` condition resolution, including rules inside `allOf`
- update classic and stepped forms dynamically, including nested and root-level conditions
- merge and restore branch-specific field constraints, conditional required state, and array item schemas
- document the supported JSON Schema annotations and add regression coverage

## Why

Forms need conditional fields without a Flutter-only annotation system. Reusing standard JSON Schema annotations keeps schemas portable with React JSON Schema Form.

## Validation

- `fvm flutter test --no-pub` — 71 tests passed
- `fvm dart analyze` — no issues
- Ponytail simplification review completed; formatting churn and unnecessary helpers removed
- CodeRabbit reviewed the committed changes and all completed findings were fixed; its final confirmation attempt was rate-limited after the last fix

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/doneservices/codesmith/flutter_jsonschema_builder/pr/19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786732308&installation_id=141069855&pr_number=19&repository=doneservices%2Fflutter_jsonschema_builder&return_to=https%3A%2F%2Fgithub.com%2Fdoneservices%2Fflutter_jsonschema_builder%2Fpull%2F19&signature=617a38385e21e6082327fc03c1e9c133ac259b3cd1a8a5552510ed5c163dffb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RJSF-compatible JSON Schema conditional fields (`if`/`then`/`else`), including conditional rules provided within `allOf`.
  * Conditional fields, step insertion/removal, and “Required” validation states now update dynamically as values change, including nested conditional behavior.
  * Expanded documentation with a “Conditional fields” usage section, full examples, supported predicates, and continued support for `dependencies`.
* **Bug Fixes**
  * Improved numeric condition handling for text-backed inputs while preserving exact `const`/`enum` string matches.  
* **Tests**
  * Added comprehensive unit/widget coverage for conditional branching and UI behavior in classic and stepped modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->